### PR TITLE
Potential fix for code scanning alert no. 24: Missing rate limiting

### DIFF
--- a/apps/api/src/routes/google-calendar.ts
+++ b/apps/api/src/routes/google-calendar.ts
@@ -47,65 +47,76 @@ export async function googleCalendarRoutes(app: FastifyInstance): Promise<void> 
     })
   );
 
-  app.get("/api/google/calendar/connect/callback", async (request, reply) => {
-    const parsed = CallbackQuerySchema.safeParse(request.query ?? {});
-    if (!parsed.success) {
-      return reply
-        .type("text/html; charset=utf-8")
-        .send(
-          renderGoogleCalendarOauthPopupPage({
-            status: "error",
-            message: "Google Calendar callback payload is invalid."
-          })
-        );
-    }
+  app.get(
+    "/api/google/calendar/connect/callback",
+    {
+      config: {
+        rateLimit: {
+          max: 20,
+          timeWindow: "1 minute"
+        }
+      }
+    },
+    async (request, reply) => {
+      const parsed = CallbackQuerySchema.safeParse(request.query ?? {});
+      if (!parsed.success) {
+        return reply
+          .type("text/html; charset=utf-8")
+          .send(
+            renderGoogleCalendarOauthPopupPage({
+              status: "error",
+              message: "Google Calendar callback payload is invalid."
+            })
+          );
+      }
 
-    if (parsed.data.error) {
-      return reply
-        .type("text/html; charset=utf-8")
-        .send(
-          renderGoogleCalendarOauthPopupPage({
-            status: "error",
-            message: parsed.data.error_description || parsed.data.error
-          })
-        );
-    }
+      if (parsed.data.error) {
+        return reply
+          .type("text/html; charset=utf-8")
+          .send(
+            renderGoogleCalendarOauthPopupPage({
+              status: "error",
+              message: parsed.data.error_description || parsed.data.error
+            })
+          );
+      }
 
-    if (!parsed.data.code || !parsed.data.state) {
-      return reply
-        .type("text/html; charset=utf-8")
-        .send(
-          renderGoogleCalendarOauthPopupPage({
-            status: "error",
-            message: "Missing Google authorization code or state."
-          })
-        );
-    }
+      if (!parsed.data.code || !parsed.data.state) {
+        return reply
+          .type("text/html; charset=utf-8")
+          .send(
+            renderGoogleCalendarOauthPopupPage({
+              status: "error",
+              message: "Missing Google authorization code or state."
+            })
+          );
+      }
 
-    try {
-      const connection = await completeGoogleCalendarOAuthCallback({
-        code: parsed.data.code,
-        state: parsed.data.state
-      });
-      return reply
-        .type("text/html; charset=utf-8")
-        .send(
-          renderGoogleCalendarOauthPopupPage({
-            status: "success",
-            message: `Connected as ${connection.googleEmail}.`
-          })
-        );
-    } catch (error) {
-      return reply
-        .type("text/html; charset=utf-8")
-        .send(
-          renderGoogleCalendarOauthPopupPage({
-            status: "error",
-            message: (error as Error).message
-          })
-        );
+      try {
+        const connection = await completeGoogleCalendarOAuthCallback({
+          code: parsed.data.code,
+          state: parsed.data.state
+        });
+        return reply
+          .type("text/html; charset=utf-8")
+          .send(
+            renderGoogleCalendarOauthPopupPage({
+              status: "success",
+              message: `Connected as ${connection.googleEmail}.`
+            })
+          );
+      } catch (error) {
+        return reply
+          .type("text/html; charset=utf-8")
+          .send(
+            renderGoogleCalendarOauthPopupPage({
+              status: "error",
+              message: (error as Error).message
+            })
+          );
+      }
     }
-  });
+  );
 
   app.post(
     "/api/google/calendar/disconnect",


### PR DESCRIPTION
Potential fix for [https://github.com/sumitdas4u/WAgen/security/code-scanning/24](https://github.com/sumitdas4u/WAgen/security/code-scanning/24)

Add a route-level rate limiter to the OAuth callback endpoint (`/api/google/calendar/connect/callback`) so repeated requests from the same client are throttled before expensive authorization/OAuth processing runs.

Best fix in this file: attach Fastify’s built-in rate-limit config to that single route via `config.rateLimit` (assuming the app has `@fastify/rate-limit` registered globally, which is the standard Fastify pattern). This keeps existing behavior intact while limiting abuse of this public callback path. No service logic changes are needed; only the route options object for the callback route needs to be added.

Edit region:
- `apps/api/src/routes/google-calendar.ts`
- Around the callback route currently declared as:
  - `app.get("/api/google/calendar/connect/callback", async (request, reply) => { ... })`
- Change it to:
  - `app.get("/api/google/calendar/connect/callback", { config: { rateLimit: { ... } } }, async (...) => { ... })`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
