### PR TITLE
Potential fix for code scanning alert no. 20: Server-side request forgery

### DIFF
--- a/apps/api/src/routes/flows.ts
+++ b/apps/api/src/routes/flows.ts
@@ -252,6 +252,27 @@ export async function flowRoutes(app: FastifyInstance) {
       }
 
       if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+        return reply.status(400).send({ error: "Only http and https URLs are allowed." });
+      }
+
+      if (parsedUrl.username || parsedUrl.password) {
+        return reply.status(400).send({ error: "URLs with embedded credentials are not allowed." });
+      }
+
+      if (isBlockedHostname(parsedUrl.hostname)) {
+        return reply.status(400).send({ error: "Target host is not allowed." });
+      }
+
+      try {
+        const resolved = await dns.promises.lookup(parsedUrl.hostname, { all: true });
+        if (!resolved.length || resolved.some((entry) => isBlockedIp(entry.address))) {
+          return reply.status(400).send({ error: "Target resolves to a non-public address." });
+        }
+      } catch {
+        return reply.status(400).send({ error: "Unable to resolve target hostname." });
+      }
+
+      if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
         return reply.status(400).send({ error: "Only http and https protocols are allowed." });
       }
 
@@ -331,7 +352,7 @@ export async function flowRoutes(app: FastifyInstance) {
 
       const startedAt = Date.now();
       try {
-        const response = await fetch(url, {
+        const response = await fetch(parsedUrl.toString(), {
           method: safeMethod,
           headers: reqHeaders,
           body: hasBody ? body?.trim() : undefined,


### PR DESCRIPTION
Potential fix for [https://github.com/sumitdas4u/WAgen/security/code-scanning/20](https://github.com/sumitdas4u/WAgen/security/code-scanning/20)

General fix: never pass raw user input directly to outbound request sinks. Parse the URL, allow only `http/https`, reject credentials, resolve hostname to IPs, and block private/link-local/loopback/internal destinations (including localhost patterns). Then call `fetch` with a canonicalized safe URL string derived from the validated `URL` object.

Best fix for this file/region: in `apps/api/src/routes/flows.ts`, at the request handler for `POST /api/flows/test-api-request`, replace `fetch(url, ...)` with `fetch(parsedUrl.toString(), ...)` and add a validation gate just after URL parsing that:
- enforces protocol is `http:` or `https:`
- rejects embedded username/password
- blocks disallowed hostnames via existing `isBlockedHostname`
- resolves DNS (`dns.promises.lookup(..., { all: true })`) and rejects if any resolved IP is internal via existing IP/block helpers in this file

This preserves current functionality (user can still test external APIs) while preventing SSRF to internal infrastructure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
