### PR TITLE
feat: inbox-v2 complete V1 parity — snooze picker, timeline, bulk act…

### DIFF
--- a/apps/web/src/modules/dashboard/inbox-v2/api.ts
+++ b/apps/web/src/modules/dashboard/inbox-v2/api.ts
@@ -249,11 +249,118 @@ export function sendCsatSurvey(token: string, convId: string): Promise<{ ok: boo
   return apiFetch(token, `/api/conversations/${convId}/csat/send`, { method: "POST" });
 }
 
+// ── Notes ─────────────────────────────────────────────────────────────────────
+
+export interface ConvNote {
+  id: string;
+  content: string;
+  created_at: string;
+  sender_name: string | null;
+}
+
+export function fetchConvNotes(token: string, convId: string): Promise<{ notes: ConvNote[] }> {
+  return apiFetch(token, `/api/conversations/${convId}/notes`);
+}
+
+export function createConvNote(token: string, convId: string, content: string): Promise<{ note: ConvNote }> {
+  return apiFetch(token, `/api/conversations/${convId}/notes`, {
+    method: "POST",
+    body: JSON.stringify({ content })
+  });
+}
+
+// ── Flows ─────────────────────────────────────────────────────────────────────
+
+export interface PublishedFlowSummary {
+  id: string;
+  name: string;
+  channel: "web" | "qr" | "api";
+}
+
+export function fetchPublishedFlows(token: string): Promise<PublishedFlowSummary[]> {
+  return apiFetch<PublishedFlowSummary[]>(token, `/api/flows/published`);
+}
+
+export function assignFlow(token: string, flowId: string, convId: string): Promise<{ sessionId: string; flowId: string; flowName: string }> {
+  return apiFetch(token, `/api/flows/${flowId}/assign`, {
+    method: "POST",
+    body: JSON.stringify({ conversationId: convId })
+  });
+}
+
+// ── Templates ─────────────────────────────────────────────────────────────────
+
+export interface TemplateComponentButton {
+  type: "QUICK_REPLY" | "URL" | "PHONE_NUMBER" | "COPY_CODE" | "FLOW";
+  text: string;
+  url?: string;
+  phone_number?: string;
+  example?: string[];
+}
+
+export interface TemplateComponent {
+  type: "HEADER" | "BODY" | "FOOTER" | "BUTTONS";
+  format?: "TEXT" | "IMAGE" | "VIDEO" | "DOCUMENT" | "LOCATION";
+  text?: string;
+  buttons?: TemplateComponentButton[];
+  example?: Record<string, unknown>;
+}
+
+export interface MessageTemplate {
+  id: string;
+  userId: string;
+  connectionId: string;
+  templateId: string | null;
+  name: string;
+  category: "MARKETING" | "UTILITY" | "AUTHENTICATION";
+  language: string;
+  status: string;
+  qualityScore: string | null;
+  components: TemplateComponent[];
+  metaRejectionReason: string | null;
+  linkedNumber: string | null;
+}
+
+export function fetchApprovedTemplates(token: string, connectionId?: string | null): Promise<MessageTemplate[]> {
+  const sp = new URLSearchParams({ status: "APPROVED" });
+  if (connectionId) sp.set("connectionId", connectionId);
+  return apiFetch<{ templates: MessageTemplate[] }>(token, `/api/meta/templates?${sp}`).then((d) => d.templates);
+}
+
+export function sendTemplate(token: string, convId: string, templateId: string, variableValues?: Record<string, string>): Promise<{ ok: boolean; messageId: string | null }> {
+  return apiFetch(token, `/api/conversations/${convId}/send-template`, {
+    method: "POST",
+    body: JSON.stringify({ templateId, variableValues: variableValues ?? {} })
+  });
+}
+
+// ── AI Assist ─────────────────────────────────────────────────────────────────
+
+export function aiAssistText(token: string, text: string, action: "rewrite" | "translate", language?: string): Promise<{ text: string }> {
+  return apiFetch(token, `/api/ai-assist/text`, {
+    method: "POST",
+    body: JSON.stringify({ text, action, language })
+  });
+}
+
 // ── Contact lookup ────────────────────────────────────────────────────────
 
 export function fetchContactByPhone(token: string, phone: string): Promise<{ contact: { display_name: string | null; email: string | null; last_incoming_message_at: string | null; marketing_consent_status: string } | null }> {
   return apiFetch(token, `/api/contacts?phone=${encodeURIComponent(phone)}&limit=1`).then((d: unknown) => {
     const data = d as { items?: Array<{ display_name: string | null; email: string | null; last_incoming_message_at: string | null; marketing_consent_status: string }> };
     return { contact: data.items?.[0] ?? null };
+  });
+}
+
+// ── Outbound conversation ─────────────────────────────────────────────────
+
+export function createOutboundConversation(token: string, params: {
+  phone: string;
+  channelType: "api" | "qr";
+  initialMessage?: string;
+}): Promise<{ conversationId: string }> {
+  return apiFetch(token, `/api/conversations/outbound`, {
+    method: "POST",
+    body: JSON.stringify(params)
   });
 }

--- a/apps/web/src/modules/dashboard/inbox-v2/components/CannedManageModal.tsx
+++ b/apps/web/src/modules/dashboard/inbox-v2/components/CannedManageModal.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "../../../../lib/auth-context";
+import {
+  listCannedResponses,
+  createCannedResponse,
+  updateCannedResponse,
+  deleteCannedResponse,
+  type CannedResponse
+} from "../api";
+
+interface Props { onClose: () => void }
+
+export function CannedManageModal({ onClose }: Props) {
+  const { token } = useAuth();
+  const qc = useQueryClient();
+
+  const invalidate = () => {
+    void qc.invalidateQueries({ queryKey: ["iv2-canned-manage"] });
+    void qc.invalidateQueries({ queryKey: ["iv2-canned"] });
+  };
+
+  const query = useQuery({
+    queryKey: ["iv2-canned-manage"],
+    queryFn: () => listCannedResponses(token!),
+    enabled: !!token
+  });
+
+  const createMut = useMutation({
+    mutationFn: (p: { name: string; short_code: string; content: string }) => createCannedResponse(token!, p),
+    onSuccess: invalidate
+  });
+
+  const updateMut = useMutation({
+    mutationFn: ({ id, ...p }: { id: string; name: string; short_code: string; content: string }) =>
+      updateCannedResponse(token!, id, p),
+    onSuccess: invalidate
+  });
+
+  const deleteMut = useMutation({
+    mutationFn: (id: string) => deleteCannedResponse(token!, id),
+    onSuccess: invalidate
+  });
+
+  const [editId, setEditId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editCode, setEditCode] = useState("");
+  const [editContent, setEditContent] = useState("");
+
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newCode, setNewCode] = useState("");
+  const [newContent, setNewContent] = useState("");
+
+  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+
+  function startEdit(c: CannedResponse) {
+    setEditId(c.id); setEditName(c.name); setEditCode(c.short_code); setEditContent(c.content);
+  }
+
+  function saveEdit() {
+    if (!editId) return;
+    void updateMut.mutateAsync({ id: editId, name: editName, short_code: editCode, content: editContent })
+      .then(() => setEditId(null));
+  }
+
+  function saveNew() {
+    void createMut.mutateAsync({ name: newName, short_code: newCode, content: newContent })
+      .then(() => { setCreating(false); setNewName(""); setNewCode(""); setNewContent(""); });
+  }
+
+  const items = query.data?.cannedResponses ?? [];
+
+  const inputStyle: React.CSSProperties = {
+    width: "100%", boxSizing: "border-box", height: 34,
+    border: "1.5px solid #e2eaf4", borderRadius: 8, padding: "0 10px",
+    fontSize: 12.5, fontFamily: "Manrope, sans-serif", outline: "none",
+    background: "#fff", marginBottom: 5, display: "block"
+  };
+  const taStyle: React.CSSProperties = { ...inputStyle, height: 60, resize: "vertical" as const, padding: "6px 10px" };
+
+  return (
+    <div className="iv-modal-overlay" onClick={onClose}>
+      <div className="iv-modal iv-modal-lg" onClick={(e) => e.stopPropagation()}>
+        <div className="iv-tvd-head">
+          <strong>Canned Responses</strong>
+          <button className="iv-tvd-close" onClick={onClose}>✕</button>
+        </div>
+
+        <div style={{ flex: 1, overflowY: "auto", padding: "12px 16px", display: "flex", flexDirection: "column", gap: 8 }}>
+          {query.isLoading && <div style={{ color: "#94a3b8", fontSize: 13, padding: "8px 0" }}>Loading…</div>}
+
+          {items.map((c) =>
+            editId === c.id ? (
+              <div key={c.id} className="iv-canned-edit-row">
+                <input style={inputStyle} placeholder="Name" value={editName} onChange={(e) => setEditName(e.target.value)} />
+                <input style={inputStyle} placeholder="Short code (e.g. greet)" value={editCode} onChange={(e) => setEditCode(e.target.value)} />
+                <textarea style={taStyle} placeholder="Content…" value={editContent} onChange={(e) => setEditContent(e.target.value)} />
+                <div style={{ display: "flex", gap: 6 }}>
+                  <button className="iv-tvd-send" style={{ fontSize: 12, padding: "3px 10px", height: "auto" }} disabled={updateMut.isPending} onClick={saveEdit}>Save</button>
+                  <button className="iv-tvd-cancel" style={{ fontSize: 12, padding: "3px 10px", height: "auto" }} onClick={() => setEditId(null)}>Cancel</button>
+                </div>
+              </div>
+            ) : (
+              <div key={c.id} className="iv-canned-manage-row">
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 12.5, fontWeight: 700, color: "#122033", display: "flex", gap: 6, alignItems: "center" }}>
+                    {c.name}
+                    <span style={{ fontFamily: "monospace", fontSize: 11, color: "#2563eb", background: "#eff6ff", border: "1px solid #bfdbfe", borderRadius: 4, padding: "0 4px" }}>/{c.short_code}</span>
+                  </div>
+                  <div style={{ fontSize: 12, color: "#5f6f86", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", marginTop: 2 }}>{c.content}</div>
+                </div>
+                <div style={{ display: "flex", gap: 4, flexShrink: 0, alignItems: "center" }}>
+                  <button className="iv-btn-icon" style={{ fontSize: 13 }} onClick={() => startEdit(c)}>✎</button>
+                  {deleteConfirm === c.id ? (
+                    <>
+                      <button style={{ background: "#fee2e2", border: "none", borderRadius: 6, padding: "4px 8px", fontSize: 11, color: "#dc2626", cursor: "pointer" }} disabled={deleteMut.isPending} onClick={() => void deleteMut.mutateAsync(c.id).then(() => setDeleteConfirm(null))}>Confirm</button>
+                      <button className="iv-btn-icon" style={{ fontSize: 11 }} onClick={() => setDeleteConfirm(null)}>✕</button>
+                    </>
+                  ) : (
+                    <button className="iv-btn-icon" style={{ fontSize: 13, color: "#ef4444" }} onClick={() => setDeleteConfirm(c.id)}>🗑</button>
+                  )}
+                </div>
+              </div>
+            )
+          )}
+
+          {creating ? (
+            <div className="iv-canned-edit-row" style={{ marginTop: 4 }}>
+              <input style={inputStyle} placeholder="Name" value={newName} autoFocus onChange={(e) => setNewName(e.target.value)} />
+              <input style={inputStyle} placeholder="Short code (e.g. greet)" value={newCode} onChange={(e) => setNewCode(e.target.value)} />
+              <textarea style={taStyle} placeholder="Content…" value={newContent} onChange={(e) => setNewContent(e.target.value)} />
+              <div style={{ display: "flex", gap: 6 }}>
+                <button className="iv-tvd-send" style={{ fontSize: 12, padding: "3px 10px", height: "auto" }} disabled={createMut.isPending} onClick={saveNew}>Create</button>
+                <button className="iv-tvd-cancel" style={{ fontSize: 12, padding: "3px 10px", height: "auto" }} onClick={() => setCreating(false)}>Cancel</button>
+              </div>
+            </div>
+          ) : (
+            <button
+              style={{ display: "flex", alignItems: "center", gap: 6, background: "#f0f4ff", border: "1px dashed #c7d6f7", borderRadius: 8, padding: "9px 12px", fontSize: 12.5, color: "#2563eb", cursor: "pointer", width: "100%", marginTop: 4 }}
+              onClick={() => setCreating(true)}
+            >
+              + New canned response
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/modules/dashboard/inbox-v2/components/ComposeArea.tsx
+++ b/apps/web/src/modules/dashboard/inbox-v2/components/ComposeArea.tsx
@@ -1,27 +1,39 @@
 import { useCallback, useRef, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useConvStore } from "../store/convStore";
-import { useSendMessage } from "../queries";
+import { useSendMessage, useCreateNote } from "../queries";
 import { postTyping, listCannedResponses } from "../api";
 import { useAuth } from "../../../../lib/auth-context";
-import type { MessageTemplate } from "../../../../lib/api";
+import { uploadInboxMedia } from "../../../../lib/supabase";
 import {
   aiAssistText,
-  assignInboxFlow,
-  sendInboxConversationTemplate,
-  updateConversationAiMode,
-  fetchInboxPublishedFlows,
-  fetchInboxApprovedTemplates
-} from "../../inbox/api";
+  assignFlow,
+  sendTemplate,
+  patchAiMode,
+  fetchPublishedFlows,
+  fetchApprovedTemplates,
+  type MessageTemplate
+} from "../api";
 
 interface Props {
   convId: string;
   optimisticMap: React.MutableRefObject<Map<string, string>>;
+  replyToMsg?: import("../store/convStore").ConversationMessage | null;
+  onClearReply?: () => void;
 }
 
 
 const TRANSLATE_LANGUAGES = ["English", "Hindi", "Spanish", "French", "Arabic", "Portuguese", "Bengali", "Urdu", "Gujarati", "Marathi", "Tamil", "Telugu"];
 const PLACEHOLDER_RE = /\{\{\s*([^}]+?)\s*\}\}/g;
+const QUICK_EMOJIS = ["👍", "😊", "🙏", "✅", "🔥", "💯", "👋", "😄", "❤️", "🎉", "⚡", "📞", "📧", "💬", "🏷️", "🔔"];
+const MAX_CHARS = 4000;
+
+interface AttachedFile {
+  file: File;
+  previewUrl: string;
+  name: string;
+  mimeType: string;
+}
 
 function getTemplateBody(t: MessageTemplate): string {
   return t.components.find((c) => c.type === "BODY")?.text ?? t.name;
@@ -37,24 +49,31 @@ interface TemplateVarsState {
   template: MessageTemplate;
   vars: string[];
   values: Record<string, string>;
+  headerMediaUrl?: string | null;
 }
 
-export function ComposeArea({ convId, optimisticMap }: Props) {
+export function ComposeArea({ convId, optimisticMap, replyToMsg, onClearReply }: Props) {
   const [mode, setMode] = useState<"reply" | "note">("reply");
   const [text, setText] = useState("");
   const [showCanned, setShowCanned] = useState(false);
   const [cannedSearch, setCannedSearch] = useState("");
+  const [cannedIdx, setCannedIdx] = useState(-1);
   const [showReplyGuide, setShowReplyGuide] = useState(true);
   const [showAiAssistPopup, setShowAiAssistPopup] = useState(false);
   const [showFlowMenu, setShowFlowMenu] = useState(false);
   const [showTemplateMenu, setShowTemplateMenu] = useState(false);
   const [showTranslateSubmenu, setShowTranslateSubmenu] = useState(false);
+  const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const [isAiRewriting, setIsAiRewriting] = useState(false);
   const [templateVarsDialog, setTemplateVarsDialog] = useState<TemplateVarsState | null>(null);
   const [tookOver, setTookOver] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
+  const [attachedFiles, setAttachedFiles] = useState<AttachedFile[]>([]);
+  const [isUploading, setIsUploading] = useState(false);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const emojiPickerRef = useRef<HTMLDivElement>(null);
   const typingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const typingDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -62,6 +81,7 @@ export function ComposeArea({ convId, optimisticMap }: Props) {
   const { byId, appendMessage, upsertConv } = useConvStore();
   const conv = byId[convId];
   const sendMsg = useSendMessage();
+  const createNote = useCreateNote();
 
   const canManualReply = Boolean(conv && (conv.ai_paused || conv.manual_takeover || tookOver));
   const isApiChannel = conv?.channel_type === "api";
@@ -77,14 +97,14 @@ export function ComposeArea({ convId, optimisticMap }: Props) {
 
   const flowsQuery = useQuery({
     queryKey: ["iv2-flows"],
-    queryFn: () => fetchInboxPublishedFlows(token!),
+    queryFn: () => fetchPublishedFlows(token!),
     enabled: Boolean(token),
     staleTime: 60_000
   });
 
   const templatesQuery = useQuery({
     queryKey: ["iv2-templates", conv?.channel_linked_number ?? "all"],
-    queryFn: () => fetchInboxApprovedTemplates(token!, conv?.channel_linked_number ?? null),
+    queryFn: () => fetchApprovedTemplates(token!, conv?.channel_linked_number ?? null),
     enabled: Boolean(token && isApiChannel),
     staleTime: 60_000
   });
@@ -92,7 +112,7 @@ export function ComposeArea({ convId, optimisticMap }: Props) {
   // ── Mutations ─────────────────────────────────────────────────────────────
 
   const takeOverMut = useMutation({
-    mutationFn: () => updateConversationAiMode(token!, convId, true),
+    mutationFn: () => patchAiMode(token!, convId, true),
     onSuccess: () => {
       upsertConv({ id: convId, ai_paused: true, manual_takeover: true });
       setTookOver(true);
@@ -100,14 +120,14 @@ export function ComposeArea({ convId, optimisticMap }: Props) {
   });
 
   const assignFlowMut = useMutation({
-    mutationFn: ({ flowId }: { flowId: string }) => assignInboxFlow(token!, convId, flowId),
+    mutationFn: ({ flowId }: { flowId: string }) => assignFlow(token!, flowId, convId),
     onSuccess: () => { setShowFlowMenu(false); showToast("Flow assigned"); },
     onError: (e: Error) => showToast(e.message)
   });
 
   const sendTemplateMut = useMutation({
     mutationFn: ({ templateId, vars }: { templateId: string; vars: Record<string, string> }) =>
-      sendInboxConversationTemplate(token!, convId, templateId, vars),
+      sendTemplate(token!, convId, templateId, vars),
     onSuccess: () => { setShowTemplateMenu(false); setTemplateVarsDialog(null); showToast("Template sent"); },
     onError: (e: Error) => showToast(e.message)
   });
@@ -132,10 +152,11 @@ export function ComposeArea({ convId, optimisticMap }: Props) {
   }, [token, convId]);
 
   const handleInput = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const val = e.target.value;
+    const val = e.target.value.slice(0, MAX_CHARS);
     setText(val);
-    setShowCanned(val.startsWith("/") && mode === "reply");
-    if (val.startsWith("/")) setCannedSearch(val.slice(1).toLowerCase());
+    const openCanned = val.startsWith("/") && mode === "reply";
+    setShowCanned(openCanned);
+    if (openCanned) { setCannedSearch(val.slice(1).toLowerCase()); setCannedIdx(-1); }
     if (typingDebounceRef.current) clearTimeout(typingDebounceRef.current);
     typingDebounceRef.current = setTimeout(() => broadcastTyping(true), 300);
     if (typingTimerRef.current) clearTimeout(typingTimerRef.current);
@@ -150,34 +171,121 @@ export function ComposeArea({ convId, optimisticMap }: Props) {
 
   const handleSend = useCallback(async () => {
     const trimmed = text.trim();
-    if (!trimmed) return;
-    const echoId = crypto.randomUUID();
-    const tempId = `temp-${echoId}`;
-    const isPrivate = mode === "note";
-    appendMessage(convId, {
-      id: tempId, conversation_id: convId, direction: "outbound", sender_name: null,
-      message_text: trimmed, content_type: "text", is_private: isPrivate,
-      in_reply_to_id: null, echo_id: echoId, delivery_status: "pending",
-      error_code: null, error_message: null, retry_count: 0, payload_json: null,
-      created_at: new Date().toISOString()
-    });
-    optimisticMap.current.set(echoId, tempId);
-    setText("");
-    setShowCanned(false);
-    broadcastTyping(false);
-    try {
-      await sendMsg.mutateAsync({ convId, params: { text: trimmed, echoId, isPrivate } });
-    } catch {
-      const { patchMessageDelivery } = useConvStore.getState();
-      patchMessageDelivery(convId, tempId, "failed");
-      optimisticMap.current.delete(echoId);
+    const hasFiles = attachedFiles.length > 0;
+    if (!trimmed && !hasFiles) return;
+    setIsUploading(hasFiles);
+
+    // Upload files first (one at a time)
+    const uploads: Array<{ url: string; mimeType: string }> = [];
+    if (hasFiles) {
+      try {
+        for (const af of attachedFiles) {
+          const result = await uploadInboxMedia(af.file);
+          uploads.push(result);
+        }
+      } catch (e) {
+        showToast((e as Error).message);
+        setIsUploading(false);
+        return;
+      }
     }
-  }, [text, mode, convId, appendMessage, optimisticMap, sendMsg, broadcastTyping]);
+
+    setIsUploading(false);
+    const isPrivate = mode === "note";
+
+    // Send one message per file, then text
+    for (const upload of uploads) {
+      const echoId = crypto.randomUUID();
+      const tempId = `temp-${echoId}`;
+      appendMessage(convId, {
+        id: tempId, conversation_id: convId, direction: "outbound", sender_name: null,
+        message_text: upload.url, content_type: upload.mimeType.startsWith("image/") ? "image" : upload.mimeType.startsWith("video/") ? "video" : upload.mimeType.startsWith("audio/") ? "audio" : "document",
+        is_private: isPrivate, in_reply_to_id: null, echo_id: echoId, delivery_status: "pending",
+        error_code: null, error_message: null, retry_count: 0, payload_json: { url: upload.url },
+        ai_model: null, total_tokens: null, created_at: new Date().toISOString()
+      });
+      optimisticMap.current.set(echoId, tempId);
+      void sendMsg.mutateAsync({ convId, params: { mediaUrl: upload.url, mediaMimeType: upload.mimeType, echoId, isPrivate } }).catch(() => {
+        useConvStore.getState().patchMessageDelivery(convId, tempId, "failed");
+        optimisticMap.current.delete(echoId);
+      });
+    }
+
+    setAttachedFiles([]);
+
+    if (trimmed) {
+      setText("");
+      setShowCanned(false);
+      setCannedIdx(-1);
+      broadcastTyping(false);
+
+      if (isPrivate) {
+        // Notes use dedicated endpoint — stored separately, always visible after reload
+        try {
+          await createNote.mutateAsync({ convId, content: trimmed });
+        } catch (e) {
+          showToast((e as Error).message);
+        }
+      } else {
+        const echoId = crypto.randomUUID();
+        const tempId = `temp-${echoId}`;
+        const replyToId = replyToMsg?.id ?? null;
+        appendMessage(convId, {
+          id: tempId, conversation_id: convId, direction: "outbound", sender_name: null,
+          message_text: trimmed, content_type: "text", is_private: false,
+          in_reply_to_id: replyToId, echo_id: echoId, delivery_status: "pending",
+          error_code: null, error_message: null, retry_count: 0, payload_json: null,
+          ai_model: null, total_tokens: null, created_at: new Date().toISOString()
+        });
+        optimisticMap.current.set(echoId, tempId);
+        onClearReply?.();
+        try {
+          await sendMsg.mutateAsync({ convId, params: { text: trimmed, echoId, isPrivate: false, inReplyToId: replyToId } });
+        } catch {
+          useConvStore.getState().patchMessageDelivery(convId, tempId, "failed");
+          optimisticMap.current.delete(echoId);
+        }
+      }
+    } else {
+      setText("");
+      setShowCanned(false);
+      setCannedIdx(-1);
+      broadcastTyping(false);
+    }
+  }, [text, attachedFiles, mode, convId, appendMessage, optimisticMap, sendMsg, broadcastTyping]);
+
+  const cannedList = cannedQuery.data?.cannedResponses ?? [];
+  const filteredCanned = cannedList.filter((c) =>
+    !cannedSearch || c.short_code.includes(cannedSearch) || c.content.toLowerCase().includes(cannedSearch)
+  );
+
+  const selectCanned = useCallback((t: string) => {
+    setText(t); setShowCanned(false); textareaRef.current?.focus();
+  }, []);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (showCanned && filteredCanned.length > 0) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setCannedIdx((i) => (i + 1) % filteredCanned.length);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setCannedIdx((i) => (i - 1 + filteredCanned.length) % filteredCanned.length);
+        return;
+      }
+      if ((e.key === "Enter" || e.key === "Tab") && cannedIdx >= 0) {
+        e.preventDefault();
+        const item = filteredCanned[cannedIdx];
+        if (item) selectCanned(item.content);
+        return;
+      }
+      if (e.key === "Escape") { setShowCanned(false); setCannedIdx(-1); return; }
+    }
     if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); void handleSend(); }
     if (e.key === "Escape") { setShowCanned(false); closeAllMenus(); }
-  }, [handleSend]);
+  }, [showCanned, filteredCanned, cannedIdx, handleSend, selectCanned]);
 
   const handleAiRewrite = useCallback(async () => {
     if (!text.trim() || isAiRewriting) return;
@@ -222,15 +330,6 @@ export function ComposeArea({ convId, optimisticMap }: Props) {
     }
   }, [sendTemplateMut]);
 
-  const cannedList = cannedQuery.data?.cannedResponses ?? [];
-  const filteredCanned = cannedList.filter((c) =>
-    !cannedSearch || c.short_code.includes(cannedSearch) || c.content.toLowerCase().includes(cannedSearch)
-  );
-
-  const selectCanned = useCallback((t: string) => {
-    setText(t); setShowCanned(false); textareaRef.current?.focus();
-  }, []);
-
   const applyFormat = useCallback((style: string) => {
     const ta = textareaRef.current;
     if (!ta) return;
@@ -244,6 +343,46 @@ export function ComposeArea({ convId, optimisticMap }: Props) {
     setText(text.slice(0, start) + open + selected + close + text.slice(end));
     setTimeout(() => { ta.setSelectionRange(start + open.length, end + open.length); ta.focus(); }, 0);
   }, [text]);
+
+  const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    const newFiles: AttachedFile[] = files.map((f) => ({
+      file: f,
+      previewUrl: f.type.startsWith("image/") ? URL.createObjectURL(f) : "",
+      name: f.name,
+      mimeType: f.type
+    }));
+    setAttachedFiles((prev) => [...prev, ...newFiles].slice(0, 5));
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }, []);
+
+  const handleRemoveAttachment = useCallback((idx: number) => {
+    setAttachedFiles((prev) => {
+      const next = [...prev];
+      if (next[idx]?.previewUrl) URL.revokeObjectURL(next[idx].previewUrl);
+      next.splice(idx, 1);
+      return next;
+    });
+  }, []);
+
+  const handlePaste = useCallback((e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    if (mode !== "reply") return;
+    const imageItem = Array.from(e.clipboardData.items).find((item) => item.type.startsWith("image/"));
+    if (!imageItem) return;
+    e.preventDefault();
+    const file = imageItem.getAsFile();
+    if (!file) return;
+    const named = new File([file], `paste-${Date.now()}.png`, { type: file.type });
+    setAttachedFiles((prev) => [...prev, {
+      file: named, previewUrl: URL.createObjectURL(named), name: named.name, mimeType: named.type
+    }].slice(0, 5));
+  }, [mode]);
+
+  const handleEmojiSelect = useCallback((emoji: string) => {
+    setText((prev) => prev + emoji);
+    setShowEmojiPicker(false);
+    textareaRef.current?.focus();
+  }, []);
 
   const flows = flowsQuery.data ?? [];
   const templates = templatesQuery.data ?? [];
@@ -266,6 +405,30 @@ export function ComposeArea({ convId, optimisticMap }: Props) {
               <button className="iv-tvd-close" onClick={() => setTemplateVarsDialog(null)}>✕</button>
             </div>
             <div className="iv-tvd-preview">{getTemplateBody(templateVarsDialog.template)}</div>
+            {/* Header media upload (for MARKETING templates with image/video/pdf header) */}
+            {templateVarsDialog.template.category === "MARKETING" && (
+              <div className="iv-tvd-field">
+                <label className="iv-tvd-label">Header media (image/video/PDF)</label>
+                <input
+                  type="file"
+                  accept="image/*,video/*,application/pdf"
+                  className="iv-tvd-input"
+                  onChange={async (e) => {
+                    const file = e.target.files?.[0];
+                    if (!file) return;
+                    try {
+                      const result = await uploadInboxMedia(file);
+                      setTemplateVarsDialog((prev) => prev ? { ...prev, headerMediaUrl: result.url } : prev);
+                    } catch (err) {
+                      showToast((err as Error).message);
+                    }
+                  }}
+                />
+                {templateVarsDialog.headerMediaUrl && (
+                  <div style={{ fontSize: 11, color: "#22c55e", marginTop: 2 }}>✓ Uploaded</div>
+                )}
+              </div>
+            )}
             {templateVarsDialog.vars.length > 0 && (
               <div className="iv-tvd-fields">
                 {templateVarsDialog.vars.map((v) => (
@@ -288,7 +451,12 @@ export function ComposeArea({ convId, optimisticMap }: Props) {
               <button
                 className="iv-tvd-send"
                 disabled={sendTemplateMut.isPending}
-                onClick={() => sendTemplateMut.mutate({ templateId: templateVarsDialog.template.id, vars: templateVarsDialog.values })}
+                onClick={() => sendTemplateMut.mutate({
+                  templateId: templateVarsDialog.template.id,
+                  vars: templateVarsDialog.headerMediaUrl
+                    ? { ...templateVarsDialog.values, headerMediaUrl: templateVarsDialog.headerMediaUrl }
+                    : templateVarsDialog.values
+                })}
               >
                 {sendTemplateMut.isPending ? "Sending…" : "Send Template"}
               </button>
@@ -307,8 +475,12 @@ export function ComposeArea({ convId, optimisticMap }: Props) {
             onChange={(e) => setCannedSearch(e.target.value)}
             autoFocus
           />
-          {filteredCanned.map((c) => (
-            <div key={c.id} className="iv-canned-item" onClick={() => selectCanned(c.content)}>
+          {filteredCanned.map((c, i) => (
+            <div
+              key={c.id}
+              className={`iv-canned-item${cannedIdx === i ? " selected" : ""}`}
+              onClick={() => selectCanned(c.content)}
+            >
               <span className="iv-canned-key">/{c.short_code}</span>
               <span className="iv-canned-text">{c.content}</span>
             </div>
@@ -357,6 +529,33 @@ export function ComposeArea({ convId, optimisticMap }: Props) {
             <button className="iv-fmt-btn" title="List">≡</button>
           </div>
 
+          {/* Attachment preview strip */}
+          {attachedFiles.length > 0 && (
+            <div className="iv-attachment-strip">
+              {attachedFiles.map((af, i) => (
+                <div key={i} className="iv-attachment-thumb">
+                  {af.previewUrl
+                    ? <img src={af.previewUrl} alt={af.name} />
+                    : <span className="iv-attachment-file-icon">📄</span>
+                  }
+                  <span className="iv-attachment-name">{af.name.slice(0, 20)}</span>
+                  <button className="iv-attachment-remove" onClick={() => handleRemoveAttachment(i)}>✕</button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Reply-to preview */}
+          {replyToMsg && (
+            <div className="iv-reply-to-strip">
+              <span className="iv-reply-to-icon">↩</span>
+              <span className="iv-reply-to-text">
+                {(replyToMsg.message_text ?? "").slice(0, 80) || "Media"}
+              </span>
+              <button className="iv-reply-to-clear" onClick={onClearReply} title="Cancel reply">✕</button>
+            </div>
+          )}
+
           {/* Textarea */}
           <textarea
             ref={textareaRef}
@@ -366,7 +565,13 @@ export function ComposeArea({ convId, optimisticMap }: Props) {
             onChange={handleInput}
             onBlur={handleBlur}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
           />
+          {text.length > MAX_CHARS * 0.9 && (
+            <div className="iv-char-counter" style={{ color: text.length >= MAX_CHARS ? "#ef4444" : "#94a3b8" }}>
+              {text.length}/{MAX_CHARS}
+            </div>
+          )}
 
           {/* Toolbar with dropups */}
           <div className="iv-compose-footer" style={{ position: "relative" }}>
@@ -453,8 +658,34 @@ export function ComposeArea({ convId, optimisticMap }: Props) {
               </div>
             )}
 
-            <button className="iv-footer-btn" title="Emoji">😊</button>
-            <button className="iv-footer-btn" title="Attach">📎</button>
+            {/* Hidden file input */}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*,video/*,audio/*,application/pdf,.doc,.docx,.txt"
+              multiple
+              style={{ display: "none" }}
+              onChange={handleFileSelect}
+            />
+            {/* Emoji picker */}
+            {showEmojiPicker && (
+              <div className="iv-emoji-picker" ref={emojiPickerRef}>
+                {QUICK_EMOJIS.map((emoji) => (
+                  <button key={emoji} className="iv-emoji-btn" onClick={() => handleEmojiSelect(emoji)}>{emoji}</button>
+                ))}
+              </div>
+            )}
+            <button
+              className={`iv-footer-btn${showEmojiPicker ? " active" : ""}`}
+              title="Emoji"
+              onClick={() => { setShowEmojiPicker((v) => !v); closeAllMenus(); }}
+            >😊</button>
+            <button
+              className="iv-footer-btn"
+              title="Attach file"
+              disabled={attachedFiles.length >= 5}
+              onClick={() => fileInputRef.current?.click()}
+            >📎</button>
             {mode === "reply" && (
               <>
                 <button
@@ -484,8 +715,8 @@ export function ComposeArea({ convId, optimisticMap }: Props) {
               ✨
             </button>
             <div className="iv-send-group">
-              <button className="iv-btn-send" onClick={() => void handleSend()}>
-                {mode === "note" ? "Add Note" : "Send ↵"}
+              <button className="iv-btn-send" disabled={isUploading} onClick={() => void handleSend()}>
+                {isUploading ? "Uploading…" : mode === "note" ? "Add Note" : "Send ↵"}
               </button>
               <button className="iv-btn-send-caret">▾</button>
             </div>

--- a/apps/web/src/modules/dashboard/inbox-v2/components/ConversationList.tsx
+++ b/apps/web/src/modules/dashboard/inbox-v2/components/ConversationList.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useConvStore, type ConvFolder, type Conversation } from "../store/convStore";
-import { useConversations } from "../queries";
+import { useConversations, useBulkAction } from "../queries";
 import { ConversationRow } from "./ConversationRow";
 import { NotificationBell } from "./NotificationsPanel";
 
@@ -15,6 +15,8 @@ const FOLDERS: { key: ConvFolder; label: string }[] = [
 
 interface Props {
   onSelectConv: (id: string) => void;
+  onNew?: () => void;
+  onCannedManage?: () => void;
 }
 
 function scoreToStage(score: number) {
@@ -31,14 +33,18 @@ function applyLeadFilters(conv: Conversation, filters: import("../store/convStor
   if (filters.aiMode === "ai" && (conv.ai_paused || conv.manual_takeover)) return false;
   if (filters.aiMode === "human" && !conv.ai_paused && !conv.manual_takeover) return false;
   if (filters.labelId !== "all" && !(conv.label_ids ?? []).includes(filters.labelId)) return false;
+  if (filters.leadKind !== "all" && conv.lead_kind !== filters.leadKind) return false;
+  if (filters.priority !== "all" && conv.priority !== filters.priority) return false;
   return true;
 }
 
-export function ConversationList({ onSelectConv }: Props) {
+export function ConversationList({ onSelectConv, onNew, onCannedManage }: Props) {
   const { folder, setFolder, byId, ids, activeConvId, setActiveConv, labels, filters } = useConvStore();
   const [searchQ, setSearchQ] = useState("");
   const [debouncedQ, setDebouncedQ] = useState("");
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const parentRef = useRef<HTMLDivElement>(null);
+  const bulkAction = useBulkAction();
 
   const { fetchNextPage, hasNextPage, isFetchingNextPage } = useConversations(folder, debouncedQ);
 
@@ -70,6 +76,19 @@ export function ConversationList({ onSelectConv }: Props) {
     onSelectConv(id);
   }, [setActiveConv, onSelectConv]);
 
+  const handleToggleSelect = useCallback((id: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const handleBulk = useCallback((action: string) => {
+    void bulkAction.mutateAsync({ ids: [...selectedIds], action }).then(() => setSelectedIds(new Set()));
+  }, [selectedIds, bulkAction]);
+
   // Load more when last item visible
   useEffect(() => {
     const lastItem = items[items.length - 1];
@@ -92,8 +111,25 @@ export function ConversationList({ onSelectConv }: Props) {
         <div className="iv-convlist-title">
           Inbox
           <span className="iv-status-pill iv-status-open">{folderCounts.open ?? 0} open</span>
-          <span style={{ marginLeft: "auto" }}><NotificationBell /></span>
+          <div style={{ marginLeft: "auto", display: "flex", gap: 4 }}>
+            {onCannedManage && (
+              <button className="iv-btn-icon" title="Manage canned responses" style={{ fontSize: 13 }} onClick={onCannedManage}>⚡</button>
+            )}
+            {onNew && (
+              <button className="iv-btn-icon" title="New conversation" style={{ fontSize: 16, fontWeight: 700 }} onClick={onNew}>+</button>
+            )}
+            <NotificationBell />
+          </div>
         </div>
+
+        {selectedIds.size > 0 && (
+          <div className="iv-bulk-bar">
+            <span className="iv-bulk-count">{selectedIds.size} selected</span>
+            <button className="iv-bulk-btn" disabled={bulkAction.isPending} onClick={() => handleBulk("resolve")}>Resolve</button>
+            <button className="iv-bulk-btn" disabled={bulkAction.isPending} onClick={() => handleBulk("reopen")}>Reopen</button>
+            <button className="iv-bulk-btn iv-bulk-cancel" onClick={() => setSelectedIds(new Set())}>✕ Clear</button>
+          </div>
+        )}
 
         <div className="iv-tabs">
           {FOLDERS.map((f) => (
@@ -141,6 +177,9 @@ export function ConversationList({ onSelectConv }: Props) {
                   conv={conv as Conversation}
                   labels={labels}
                   active={activeConvId === id}
+                  selected={selectedIds.has(id)}
+                  hasSelection={selectedIds.size > 0}
+                  onToggleSelect={(e) => handleToggleSelect(id, e)}
                   onClick={() => handleSelect(id)}
                 />
               </div>

--- a/apps/web/src/modules/dashboard/inbox-v2/components/ConversationRow.tsx
+++ b/apps/web/src/modules/dashboard/inbox-v2/components/ConversationRow.tsx
@@ -3,14 +3,30 @@ import type { Conversation, Label } from "../store/convStore";
 
 const AVATAR_COLORS = ["blue", "green", "purple", "amber", "rose", "teal"] as const;
 
+function seedChar(s: string): number {
+  return s ? s.charCodeAt(0) : 0;
+}
+
 export function getAvatarColor(phone: string): string {
-  const n = parseInt(phone.replace(/\D/g, "").slice(-1)) || 0;
+  const n = parseInt((phone ?? "").replace(/\D/g, "").slice(-1)) || 0;
   return AVATAR_COLORS[n % AVATAR_COLORS.length];
 }
 
-function getInitials(phone: string): string {
-  const digits = phone.replace(/\D/g, "");
-  return digits.slice(-2);
+export function getNameAvatarColor(name: string | null | undefined, phone: string): string {
+  if (name) {
+    const n = (seedChar(name[0] ?? "") + seedChar(name[name.length - 1] ?? "")) % AVATAR_COLORS.length;
+    return AVATAR_COLORS[n];
+  }
+  return getAvatarColor(phone);
+}
+
+export function getNameInitials(name: string | null | undefined, phone: string): string {
+  if (name) {
+    const words = name.trim().split(/\s+/);
+    if (words.length >= 2) return `${words[0][0] ?? ""}${words[words.length - 1][0] ?? ""}`.toUpperCase();
+    return (words[0] ?? "").slice(0, 2).toUpperCase();
+  }
+  return (phone ?? "").replace(/\D/g, "").slice(-2);
 }
 
 function relativeTime(ts: string | null): string {
@@ -22,17 +38,27 @@ function relativeTime(ts: string | null): string {
   }
 }
 
+function getScoreBand(score: number): "hot" | "warm" | "cold" {
+  if (score >= 70) return "hot";
+  if (score >= 40) return "warm";
+  return "cold";
+}
+
 interface Props {
   conv: Conversation;
   labels: Label[];
   active: boolean;
   onClick: () => void;
+  selected?: boolean;
+  hasSelection?: boolean;
+  onToggleSelect?: (e: React.MouseEvent) => void;
 }
 
-export function ConversationRow({ conv, labels, active, onClick }: Props) {
-  const avatarColor = getAvatarColor(conv.phone_number);
-  const initials = getInitials(conv.phone_number);
-  const convLabels = labels.filter((l) => (conv as unknown as Record<string, string[]>).label_ids?.includes(l.id));
+export function ConversationRow({ conv, labels, active, onClick, selected, hasSelection, onToggleSelect }: Props) {
+  const avatarColor = getNameAvatarColor(conv.contact_name, conv.phone_number);
+  const initials = getNameInitials(conv.contact_name, conv.phone_number);
+  const displayName = conv.contact_name || conv.phone_number;
+  const convLabels = labels.filter((l) => conv.label_ids?.includes(l.id));
 
   const channelClass = conv.channel_type === "api" ? "iv-ch-api" : conv.channel_type === "web" ? "iv-ch-web" : "iv-ch-qr";
   const channelLabel = conv.channel_type === "api" ? "A" : conv.channel_type === "web" ? "W" : "Q";
@@ -42,7 +68,15 @@ export function ConversationRow({ conv, labels, active, onClick }: Props) {
     : null;
 
   return (
-    <div className={`iv-crow${active ? " active" : ""}`} onClick={onClick}>
+    <div className={`iv-crow${active ? " active" : ""}${selected ? " selected" : ""}`} onClick={onClick}>
+      {(hasSelection || selected) && (
+        <div
+          className="iv-crow-check"
+          onClick={onToggleSelect}
+        >
+          <div className={`iv-checkbox${selected ? " checked" : ""}`} />
+        </div>
+      )}
       <div className="iv-crow-avatar-wrap">
         <div className={`iv-avatar av-${avatarColor}`}>{initials}</div>
         <div className={`iv-channel-dot ${channelClass}`}>{channelLabel}</div>
@@ -50,9 +84,9 @@ export function ConversationRow({ conv, labels, active, onClick }: Props) {
 
       <div className="iv-crow-body">
         <div className="iv-crow-source">⊙ {conv.channel_type === "api" ? "WhatsApp API" : conv.channel_type === "web" ? "Web Widget" : "WhatsApp QR"}</div>
-        <div className="iv-crow-name">{conv.phone_number}</div>
+        <div className="iv-crow-name">{displayName}</div>
         <div className="iv-crow-snippet">
-          {conv.last_message ?? "No messages yet"}
+          {typeof conv.last_message === "string" ? conv.last_message : "No messages yet"}
         </div>
         {convLabels.length > 0 && (
           <div className="iv-crow-labels">
@@ -73,6 +107,9 @@ export function ConversationRow({ conv, labels, active, onClick }: Props) {
         )}
         {priorityDot}
         {conv.ai_paused && <span className="iv-ai-paused">⏸</span>}
+        {conv.score > 0 && (
+          <span className={`iv-score-chip iv-score-${getScoreBand(conv.score)}`}>{conv.score}</span>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/modules/dashboard/inbox-v2/components/DetailsSidebar.tsx
+++ b/apps/web/src/modules/dashboard/inbox-v2/components/DetailsSidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useConvStore } from "../store/convStore";
@@ -83,6 +83,8 @@ interface Props { convId: string }
 
 export function DetailsSidebar({ convId }: Props) {
   const [openSections, setOpenSections] = useState<Set<string>>(getSavedSections);
+  const [snoozeAt, setSnoozeAt] = useState("");
+  const [pendingSnooze, setPendingSnooze] = useState(false);
 
   const { byId, labels } = useConvStore();
   const conv = byId[convId];
@@ -144,6 +146,11 @@ export function DetailsSidebar({ convId }: Props) {
     return { id: def.id, label: def.label, field_type: def.field_type, value: fv?.value ?? null };
   });
   const orphans = fieldValues.filter((fv) => !fieldDefs.some((d) => d.id === fv.field_id));
+
+  useEffect(() => {
+    setPendingSnooze(false);
+    setSnoozeAt("");
+  }, [convId]);
 
   const toggleSection = useCallback((id: string) => {
     setOpenSections((prev) => {
@@ -232,16 +239,50 @@ export function DetailsSidebar({ convId }: Props) {
 
           {/* Conversation Actions */}
           <Accordion id="conv-actions" title="Conversation Actions" open={openSections.has("conv-actions")} onToggle={() => toggleSection("conv-actions")}>
-            <div className="iv-acc-row">
-              <span className="iv-acc-key">Status</span>
-              <select
-                className="iv-acc-val"
-                value={conv.status ?? "open"}
-                style={{ border: "1px solid #e2eaf4", borderRadius: 6, padding: "2px 6px", fontSize: 12, background: "#fff" }}
-                onChange={(e) => setStatus.mutate({ convId, status: e.target.value })}
-              >
-                {["open", "pending", "resolved", "snoozed"].map((s) => <option key={s} value={s}>{s}</option>)}
-              </select>
+            <div className="iv-acc-row" style={{ flexDirection: "column", gap: 4 }}>
+              <div style={{ display: "flex", gap: 8 }}>
+                <span className="iv-acc-key" style={{ paddingTop: 4 }}>Status</span>
+                <select
+                  className="iv-acc-val"
+                  value={pendingSnooze ? "snoozed" : (conv.status ?? "open")}
+                  style={{ border: "1px solid #e2eaf4", borderRadius: 6, padding: "2px 6px", fontSize: 12, background: "#fff" }}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    if (val === "snoozed") {
+                      const d = new Date(); d.setHours(d.getHours() + 1);
+                      setSnoozeAt(d.toISOString().slice(0, 16));
+                      setPendingSnooze(true);
+                    } else {
+                      setPendingSnooze(false);
+                      setStatus.mutate({ convId, status: val });
+                    }
+                  }}
+                >
+                  {["open", "pending", "resolved", "snoozed"].map((s) => <option key={s} value={s}>{s}</option>)}
+                </select>
+              </div>
+              {(pendingSnooze || conv.status === "snoozed") && (
+                <div style={{ display: "flex", flexDirection: "column", gap: 4, paddingLeft: 88 }}>
+                  <input
+                    type="datetime-local"
+                    style={{ border: "1px solid #e2eaf4", borderRadius: 6, padding: "3px 6px", fontSize: 11.5, background: "#fff", outline: "none" }}
+                    value={snoozeAt || (conv.snoozed_until ? conv.snoozed_until.slice(0, 16) : "")}
+                    onChange={(e) => setSnoozeAt(e.target.value)}
+                  />
+                  <button
+                    className="iv-btn-blue"
+                    style={{ fontSize: 11, padding: "3px 8px", alignSelf: "flex-start" }}
+                    disabled={setStatus.isPending || !(snoozeAt || conv.snoozed_until)}
+                    onClick={() => {
+                      const val = snoozeAt || (conv.snoozed_until ? conv.snoozed_until.slice(0, 16) : "");
+                      void setStatus.mutateAsync({ convId, status: "snoozed", snoozedUntil: new Date(val).toISOString() })
+                        .then(() => setPendingSnooze(false));
+                    }}
+                  >
+                    Confirm snooze
+                  </button>
+                </div>
+              )}
             </div>
             <div className="iv-acc-row">
               <span className="iv-acc-key">Priority</span>
@@ -319,6 +360,35 @@ export function DetailsSidebar({ convId }: Props) {
           <Accordion id="conv-info" title="Conversation Info" open={openSections.has("conv-info")} onToggle={() => toggleSection("conv-info")}>
             <div className="iv-acc-row"><span className="iv-acc-key">ID</span><span className="iv-acc-val" style={{ fontSize: 11, fontFamily: "monospace" }}>{convId.slice(-8)}</span></div>
             {conv.created_at && <div className="iv-acc-row"><span className="iv-acc-key">Created</span><span className="iv-acc-val">{new Date(conv.created_at).toLocaleDateString()}</span></div>}
+            {conv.snoozed_until && <div className="iv-acc-row"><span className="iv-acc-key">Snoozed until</span><span className="iv-acc-val">{new Date(conv.snoozed_until).toLocaleString()}</span></div>}
+          </Accordion>
+
+          {/* Timeline */}
+          <Accordion id="timeline" title="Timeline" open={openSections.has("timeline")} onToggle={() => toggleSection("timeline")}>
+            <div className="iv-timeline">
+              {[
+                conv.created_at         && { icon: "💬", label: "Conversation started",  time: conv.created_at },
+                conv.last_message_at    && { icon: "📩", label: "Last message",           time: conv.last_message_at },
+                conv.last_ai_reply_at   && { icon: "🤖", label: "Last AI reply",          time: conv.last_ai_reply_at },
+                conv.agent_last_seen_at && { icon: "👁", label: "Agent last seen",        time: conv.agent_last_seen_at },
+                conv.csat_sent_at       && { icon: "⭐", label: "CSAT survey sent",       time: conv.csat_sent_at },
+              ]
+                .filter(Boolean)
+                .sort((a, b) => Date.parse((a as { time: string }).time) - Date.parse((b as { time: string }).time))
+                .map((ev, i) => {
+                  const e = ev as { icon: string; label: string; time: string };
+                  return (
+                    <div key={i} className="iv-timeline-item">
+                      <span className="iv-timeline-icon">{e.icon}</span>
+                      <div className="iv-timeline-body">
+                        <span className="iv-timeline-label">{e.label}</span>
+                        <span className="iv-timeline-time">{new Date(e.time).toLocaleString()}</span>
+                      </div>
+                    </div>
+                  );
+                })
+              }
+            </div>
           </Accordion>
 
           {/* CSAT */}

--- a/apps/web/src/modules/dashboard/inbox-v2/components/LeadFiltersPanel.tsx
+++ b/apps/web/src/modules/dashboard/inbox-v2/components/LeadFiltersPanel.tsx
@@ -57,22 +57,29 @@ interface Props { conversations: Conversation[] }
 export function LeadFiltersPanel({ conversations }: Props) {
   const { filters, setFilters, labels, folder, setFolder } = useConvStore();
 
-  const total = conversations.length;
-  const unattended = conversations.filter((c) => c.ai_paused || c.manual_takeover).length;
   const hotCount = conversations.filter((c) => scoreToStage(c.score) === "hot").length;
+  const warmCount = conversations.filter((c) => scoreToStage(c.score) === "warm").length;
+  const coldCount = conversations.filter((c) => scoreToStage(c.score) === "cold").length;
   const pendingCount = conversations.filter((c) => c.status === "pending").length;
   const apiCount = conversations.filter((c) => c.channel_type === "api").length;
   const qrCount = conversations.filter((c) => c.channel_type === "qr").length;
   const webCount = conversations.filter((c) => c.channel_type === "web").length;
 
-  const isDefault = filters.stage === "all" && filters.channel === "all" && filters.aiMode === "all" && filters.assignment === "all" && filters.labelId === "all";
+  const isDefault =
+    filters.stage === "all" &&
+    filters.channel === "all" &&
+    filters.aiMode === "all" &&
+    filters.assignment === "all" &&
+    filters.labelId === "all" &&
+    filters.leadKind === "all" &&
+    filters.priority === "all" &&
+    folder === "all";
 
-  // Compute which nav item is "active"
   const activeView = (() => {
-    if (filters.assignment === "assigned") return "my-inbox";
-    if (filters.stage === "hot") return "hot-leads";
+    if (filters.stage === "hot" && filters.channel === "all") return "hot-leads";
+    if (filters.stage === "warm" && filters.channel === "all") return "warm-leads";
+    if (filters.stage === "cold" && filters.channel === "all") return "cold-leads";
     if (folder === "pending") return "pending";
-    if (filters.aiMode === "human") return "unattended";
     if (filters.channel === "api") return "wa-api";
     if (filters.channel === "qr") return "wa-qr";
     if (filters.channel === "web") return "web";
@@ -81,40 +88,34 @@ export function LeadFiltersPanel({ conversations }: Props) {
   })();
 
   function selectAll() {
-    setFilters({ stage: "all", channel: "all", aiMode: "all", assignment: "all", labelId: "all" });
+    setFilters({ stage: "all", channel: "all", aiMode: "all", assignment: "all", labelId: "all", leadKind: "all", priority: "all" });
     setFolder("all");
   }
 
   return (
     <div className="iv-lf">
-      {/* CONVERSATIONS section */}
-      <NavSection title="CONVERSATIONS" />
-      <NavItem
-        label="All Conversations"
-        count={total}
-        active={activeView === "all"}
-        onClick={selectAll}
-      />
-      <NavItem
-        label="My Inbox"
-        active={activeView === "my-inbox"}
-        onClick={() => { selectAll(); setFilters({ assignment: "assigned" }); }}
-      />
-      <NavItem
-        label="Unattended"
-        count={unattended || undefined}
-        active={activeView === "unattended"}
-        onClick={() => { selectAll(); setFilters({ aiMode: "human" }); }}
-      />
-
-      {/* FOLDERS section */}
-      <NavSection title="FOLDERS" />
+      {/* LEAD STATUS section */}
+      <NavSection title="LEAD STATUS" />
       <NavItem
         label="Hot Leads"
         icon="🔥"
         count={hotCount || undefined}
         active={activeView === "hot-leads"}
         onClick={() => { selectAll(); setFilters({ stage: "hot" }); }}
+      />
+      <NavItem
+        label="Warm Leads"
+        icon="☀️"
+        count={warmCount || undefined}
+        active={activeView === "warm-leads"}
+        onClick={() => { selectAll(); setFilters({ stage: "warm" }); }}
+      />
+      <NavItem
+        label="Cold Leads"
+        icon="❄️"
+        count={coldCount || undefined}
+        active={activeView === "cold-leads"}
+        onClick={() => { selectAll(); setFilters({ stage: "cold" }); }}
       />
       <NavItem
         label="Pending Review"
@@ -152,15 +153,30 @@ export function LeadFiltersPanel({ conversations }: Props) {
       <div className="iv-nav-filters-divider" />
 
       <div className="iv-nav-filters">
-        <FilterSection label="Lead Stage">
+        <FilterSection label="Lead Type">
           <Pills
-            value={filters.stage}
-            onChange={(v) => setFilters({ stage: v })}
+            value={filters.leadKind}
+            onChange={(v) => setFilters({ leadKind: v })}
             options={[
               { label: "All", value: "all" },
-              { label: "Hot", value: "hot" },
-              { label: "Warm", value: "warm" },
-              { label: "Cold", value: "cold" }
+              { label: "Lead", value: "lead" },
+              { label: "Feedback", value: "feedback" },
+              { label: "Complaint", value: "complaint" },
+              { label: "Other", value: "other" }
+            ]}
+          />
+        </FilterSection>
+
+        <FilterSection label="Priority">
+          <Pills
+            value={filters.priority}
+            onChange={(v) => setFilters({ priority: v })}
+            options={[
+              { label: "All", value: "all" },
+              { label: "Urgent", value: "urgent" },
+              { label: "High", value: "high" },
+              { label: "Medium", value: "medium" },
+              { label: "Low", value: "low" }
             ]}
           />
         </FilterSection>
@@ -185,19 +201,6 @@ export function LeadFiltersPanel({ conversations }: Props) {
               { label: "All", value: "all" },
               { label: "Assigned", value: "assigned" },
               { label: "Unassigned", value: "unassigned" }
-            ]}
-          />
-        </FilterSection>
-
-        <FilterSection label="Channel">
-          <Pills
-            value={filters.channel}
-            onChange={(v) => setFilters({ channel: v })}
-            options={[
-              { label: "All", value: "all" },
-              { label: "QR", value: "qr" },
-              { label: "API", value: "api" },
-              { label: "Web", value: "web" }
             ]}
           />
         </FilterSection>

--- a/apps/web/src/modules/dashboard/inbox-v2/components/MessageBubble.tsx
+++ b/apps/web/src/modules/dashboard/inbox-v2/components/MessageBubble.tsx
@@ -1,15 +1,38 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
 import { format } from "date-fns";
 import type { ConversationMessage } from "../store/convStore";
-import { getAvatarColor } from "./ConversationRow";
+import { getNameAvatarColor, getNameInitials } from "./ConversationRow";
+import { API_URL } from "../../../../lib/api";
+
+const META_ERROR_SOLUTIONS: Record<string, string> = {
+  "131026": "The contact may not have WhatsApp or has blocked your number.",
+  "131047": "You can only send free-form messages within 24h of their last message. Use a template instead.",
+  "131049": "Meta flagged this as spam/quality signal. Improve template quality and reduce frequency.",
+  "131051": "Template not found or not approved in Meta Business Manager.",
+  "131052": "Template was paused by Meta due to low quality.",
+  "131053": "Media URL expired. Re-upload or use a permanent URL.",
+  "131056": "Too many messages sent to this contact. Wait before sending again.",
+  "131057": "Contact has not opted in to receive messages from your business.",
+  "130429": "Rate limit hit. Slow down message sending or upgrade your tier.",
+  "131031": "Business account locked. Check Meta Business Manager for violations.",
+  "131000": "Message undeliverable — generic Meta failure.",
+  "131008": "Required template parameter missing.",
+  "131009": "Parameter value invalid for template.",
+};
 
 interface Props {
   message: ConversationMessage;
   isFirst: boolean;
   showAvatar: boolean;
   convPhone: string;
+  contactName?: string | null;
   onRetry?: (msgId: string) => void;
+  onReply?: (msg: ConversationMessage) => void;
   quotedMessage?: ConversationMessage | null;
 }
+
+// ─── Delivery status ──────────────────────────────────────────────────────────
 
 function renderDelivery(status: string, retryCount: number, onRetry?: () => void) {
   if (status === "pending") return <span className="iv-delivery pending">⏳</span>;
@@ -38,55 +61,315 @@ function formatTime(ts: string) {
   try { return format(new Date(ts), "HH:mm"); } catch { return ""; }
 }
 
-function renderContent(msg: ConversationMessage) {
+// ─── Text formatting (WhatsApp-style) ─────────────────────────────────────────
+
+const URL_RE = /(https?:\/\/[^\s<>"]+)/g;
+const IMAGE_EXT = /\.(jpg|jpeg|png|gif|webp|bmp|svg)(\?.*)?$/i;
+const WA_FORMAT_RE = /```([\s\S]+?)```|\*([^*\n]+)\*|_([^_\n]+)_|~([^~\n]+)~/g;
+
+function resolveMediaUrl(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+  return url.startsWith("/") ? `${API_URL}${url}` : url;
+}
+
+function renderInlineSegment(text: string, keyPrefix: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  WA_FORMAT_RE.lastIndex = 0;
+  while ((match = WA_FORMAT_RE.exec(text)) !== null) {
+    if (match.index > lastIndex) nodes.push(text.slice(lastIndex, match.index));
+    const [full, mono, bold, italic, strike] = match;
+    const key = `${keyPrefix}-${match.index}`;
+    if (mono !== undefined) nodes.push(<code key={key} style={{ background: "rgba(0,0,0,0.1)", borderRadius: 3, padding: "0 3px", fontSize: "0.9em", fontFamily: "monospace" }}>{mono}</code>);
+    else if (bold !== undefined) nodes.push(<strong key={key}>{bold}</strong>);
+    else if (italic !== undefined) nodes.push(<em key={key}>{italic}</em>);
+    else if (strike !== undefined) nodes.push(<span key={key} style={{ textDecoration: "line-through" }}>{strike}</span>);
+    else nodes.push(full);
+    lastIndex = match.index + full.length;
+  }
+  if (lastIndex < text.length) nodes.push(text.slice(lastIndex));
+  return nodes;
+}
+
+function renderFormattedText(text: string | null | undefined, keyPrefix = "fmt"): ReactNode[] {
+  const lines = (text ?? "").split("\n");
+  const nodes: ReactNode[] = [];
+  lines.forEach((line, li) => {
+    const parts: ReactNode[] = [];
+    let last = 0;
+    let match: RegExpExecArray | null;
+    URL_RE.lastIndex = 0;
+    while ((match = URL_RE.exec(line)) !== null) {
+      if (match.index > last) parts.push(...renderInlineSegment(line.slice(last, match.index), `${keyPrefix}-${li}-${match.index}-t`));
+      const url = match[0];
+      const safeUrl = (() => { try { const p = new URL(url); return (p.protocol === "https:" || p.protocol === "http:") ? p.href : ""; } catch { return ""; } })();
+      if (IMAGE_EXT.test(url)) {
+        parts.push(<img key={`img-${li}-${match.index}`} src={safeUrl} alt="" loading="lazy" style={{ maxWidth: 200, borderRadius: 6, display: "block", margin: "4px 0" }} />);
+      } else {
+        parts.push(<a key={`a-${li}-${match.index}`} href={safeUrl} target="_blank" rel="noopener noreferrer" style={{ color: "inherit", textDecorationColor: "rgba(255,255,255,0.5)" }}>{url}</a>);
+      }
+      last = match.index + match[0].length;
+    }
+    if (last < line.length) parts.push(...renderInlineSegment(line.slice(last), `${keyPrefix}-${li}-tail`));
+    nodes.push(<span key={li} style={{ display: "contents" }}>{parts}</span>);
+    if (li < lines.length - 1) nodes.push(<br key={`br-${li}`} />);
+  });
+  return nodes;
+}
+
+// ─── Content renderers ────────────────────────────────────────────────────────
+
+function renderContent(msg: ConversationMessage): ReactNode {
   const type = msg.content_type ?? "text";
   const payload = msg.payload_json as Record<string, unknown> | null;
+  const text = msg.message_text ?? "";
+  const mediaUrl = resolveMediaUrl(payload?.url as string | undefined);
 
   switch (type) {
-    case "image": {
-      const url = (payload?.url as string) ?? msg.message_text;
+    case "image":
+    case "sticker": {
+      const url = mediaUrl ?? (text.startsWith("http") ? text : undefined);
+      const caption = (payload?.caption as string) ?? undefined;
+      if (!url) {
+        return (
+          <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, opacity: 0.8 }}>
+            <span>📷</span><span>{caption || "Image"}</span>
+          </div>
+        );
+      }
       return (
         <div>
-          <img src={url} alt="Image" style={{ maxWidth: 220, borderRadius: 8, cursor: "pointer" }} onClick={() => window.open(url, "_blank")} />
-          {payload?.caption != null && <p style={{ marginTop: 4, fontSize: 13, color: "inherit" }}>{String(payload.caption)}</p>}
+          <a href={url} target="_blank" rel="noopener noreferrer">
+            <img src={url} alt={caption || "Image"} loading="lazy"
+              style={{ maxWidth: 220, maxHeight: 280, borderRadius: 8, display: "block", cursor: "pointer" }} />
+          </a>
+          {caption && <p style={{ margin: "4px 0 0", fontSize: 13 }}>{renderFormattedText(caption, `cap-${msg.id}`)}</p>}
         </div>
       );
     }
+
     case "audio":
-      return <audio controls src={(payload?.url as string) ?? msg.message_text} style={{ maxWidth: 220 }} />;
-    case "video":
-      return <video controls src={(payload?.url as string) ?? msg.message_text} style={{ maxWidth: 260, borderRadius: 8 }} />;
+      return (
+        <audio controls src={mediaUrl} style={{ maxWidth: 220, display: "block" }} />
+      );
+
+    case "video": {
+      const caption = (payload?.caption as string) ?? undefined;
+      return (
+        <div>
+          <video controls src={mediaUrl} style={{ maxWidth: 260, borderRadius: 8, display: "block" }} />
+          {caption && <p style={{ margin: "4px 0 0", fontSize: 13 }}>{renderFormattedText(caption, `vcap-${msg.id}`)}</p>}
+        </div>
+      );
+    }
+
     case "document": {
-      const url = (payload?.url as string) ?? msg.message_text;
+      const filename = (payload?.filename as string) ?? (payload?.file_name as string) ?? "Document";
       return (
-        <a href={url} target="_blank" rel="noopener noreferrer" style={{ display: "flex", alignItems: "center", gap: 6, color: "inherit" }}>
-          <span>📄</span>
-          <span style={{ fontSize: 13 }}>{(payload?.filename as string) ?? "Document"}</span>
+        <a href={mediaUrl} target="_blank" rel="noopener noreferrer"
+          style={{ display: "flex", alignItems: "center", gap: 6, color: "inherit", textDecoration: "none", fontSize: 13 }}>
+          <span style={{ fontSize: 18 }}>📄</span>
+          <span style={{ textDecoration: "underline" }}>{filename}</span>
         </a>
       );
     }
+
     case "location": {
-      const lat = payload?.latitude as number;
-      const lng = payload?.longitude as number;
-      const label = (payload?.name as string) ?? msg.message_text;
+      const lat = (payload?.latitude as number) ?? 0;
+      const lng = (payload?.longitude as number) ?? 0;
+      const name = (payload?.name as string) ?? (text.replace(/^\[LOCATION\]\n?/, "").split("\n")[0]) ?? "";
+      const address = (payload?.address as string) ?? undefined;
       return (
-        <a href={`https://maps.google.com/?q=${lat},${lng}`} target="_blank" rel="noopener noreferrer" style={{ color: "inherit" }}>
-          📍 {label}
-        </a>
+        <div style={{ display: "flex", gap: 8, alignItems: "flex-start", fontSize: 13 }}>
+          <span>📍</span>
+          <div>
+            {name && <strong style={{ display: "block" }}>{name}</strong>}
+            {address && <span style={{ fontSize: 12, opacity: 0.7, display: "block" }}>{address}</span>}
+            <a href={`https://maps.google.com/?q=${lat},${lng}`} target="_blank" rel="noopener noreferrer"
+              style={{ fontSize: 12, color: "inherit", opacity: 0.85 }}>View on map →</a>
+          </div>
+        </div>
       );
     }
+
+    case "contacts": {
+      const contacts = (payload?.contacts as Array<{
+        name?: { formatted_name?: string };
+        phones?: Array<{ phone?: string }>;
+      }>) ?? [];
+      if (contacts.length > 0) {
+        return (
+          <div>
+            {contacts.map((c, i) => {
+              const name = c.name?.formatted_name ?? "Unknown";
+              const phone = c.phones?.[0]?.phone ?? "";
+              return (
+                <div key={i} style={{ display: "flex", gap: 8, alignItems: "center", padding: "4px 0" }}>
+                  <div style={{ width: 28, height: 28, borderRadius: "50%", background: "rgba(0,0,0,0.15)", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 12, fontWeight: 700, flexShrink: 0 }}>
+                    {name[0]?.toUpperCase()}
+                  </div>
+                  <div>
+                    <div style={{ fontSize: 13, fontWeight: 600 }}>{name}</div>
+                    <div style={{ fontSize: 12, opacity: 0.7 }}>{phone}</div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        );
+      }
+      return <span style={{ fontSize: 13 }}>👤 {text.replace(/^\[CONTACT\]\s?/, "")}</span>;
+    }
+
+    case "interactive": {
+      const iType = (payload?.type as string) ?? "";
+      if (iType === "list" || iType === "list_reply") {
+        const title = (payload?.body as { text?: string })?.text ?? text;
+        const sections = (payload?.action as { sections?: Array<{ title?: string; rows?: Array<{ id: string; title: string; description?: string }> }> })?.sections ?? [];
+        const items = sections.flatMap((s) => s.rows ?? []);
+        return (
+          <div style={{ fontSize: 13 }}>
+            {title && <p style={{ margin: "0 0 8px" }}>{renderFormattedText(title, `int-${msg.id}`)}</p>}
+            {items.map((item) => (
+              <div key={item.id} style={{ padding: "5px 8px", background: "rgba(0,0,0,0.07)", borderRadius: 6, marginBottom: 4 }}>
+                <div style={{ fontWeight: 600 }}>{item.title}</div>
+                {item.description && <div style={{ fontSize: 11, opacity: 0.7 }}>{item.description}</div>}
+              </div>
+            ))}
+          </div>
+        );
+      }
+      // button / button_reply
+      const bodyText = (payload?.body as { text?: string })?.text ?? text;
+      const buttons = (payload?.action as { buttons?: Array<{ reply?: { id: string; title: string } }> })?.buttons ?? [];
+      return (
+        <div style={{ fontSize: 13 }}>
+          {bodyText && <p style={{ margin: "0 0 8px" }}>{renderFormattedText(bodyText, `int-btn-${msg.id}`)}</p>}
+          {buttons.map((b, i) => (
+            <div key={b.reply?.id ?? i} style={{ display: "flex", alignItems: "center", gap: 6, padding: "5px 10px", border: "1px solid rgba(0,0,0,0.18)", borderRadius: 16, marginBottom: 4, fontSize: 12 }}>
+              <span>↩</span><span>{b.reply?.title}</span>
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    case "template": {
+      const name = (payload?.name as string) ?? "";
+      const components = (payload?.components as Array<{ type: string; text?: string }>) ?? [];
+      const bodyComp = components.find((c) => c.type === "body");
+      const headerComp = components.find((c) => c.type === "header");
+      const footerComp = components.find((c) => c.type === "footer");
+      const btnComps = components.filter((c) => c.type === "button");
+      const bodyText = bodyComp?.text ?? (payload?.body as { text?: string })?.text ?? text;
+      const headerText = headerComp?.text ?? (payload?.header as { text?: string })?.text ?? (name ? `📋 ${name}` : "");
+      return (
+        <div style={{ fontSize: 13 }}>
+          {headerText && <p style={{ margin: "0 0 4px", fontWeight: 700 }}>{headerText}</p>}
+          {bodyText && <p style={{ margin: "0 0 4px" }}>{renderFormattedText(bodyText, `tmpl-${msg.id}`)}</p>}
+          {footerComp?.text && <p style={{ margin: "0 0 4px", fontSize: 11, opacity: 0.6 }}>{footerComp.text}</p>}
+          {btnComps.map((b, i) => (
+            <div key={i} style={{ display: "flex", alignItems: "center", gap: 6, padding: "5px 10px", border: "1px solid rgba(0,0,0,0.18)", borderRadius: 16, marginBottom: 4, fontSize: 12 }}>
+              <span>↩</span><span>{b.text}</span>
+            </div>
+          ))}
+          {!bodyText && !headerText && name && <span style={{ opacity: 0.6 }}>📋 {name}</span>}
+        </div>
+      );
+    }
+
     case "activity":
-      return null; // handled separately as pill
-    default:
-      return <span style={{ whiteSpace: "pre-wrap" }}>{msg.message_text}</span>;
+      return null;
+
+    default: {
+      // Outbound WAgen payloads: text_buttons, list, poll, product_list
+      const pType = payload?.type as string | undefined;
+
+      if (pType === "text_buttons" || pType === "media_buttons") {
+        const buttons = (payload?.buttons as Array<{ id: string; label: string }>) ?? [];
+        const bodyText = (payload?.text as string) ?? (payload?.caption as string) ?? text;
+        const imgUrl = resolveMediaUrl(payload?.url as string | undefined);
+        return (
+          <div style={{ fontSize: 13 }}>
+            {imgUrl && (
+              <a href={imgUrl} target="_blank" rel="noopener noreferrer">
+                <img src={imgUrl} alt="" loading="lazy" style={{ maxWidth: 220, borderRadius: 8, display: "block", marginBottom: 6 }} />
+              </a>
+            )}
+            {bodyText && <p style={{ margin: "0 0 8px" }}>{renderFormattedText(bodyText, `btn-${msg.id}`)}</p>}
+            {buttons.map((b) => (
+              <div key={b.id} style={{ display: "flex", alignItems: "center", gap: 6, padding: "5px 10px", border: "1px solid rgba(0,0,0,0.18)", borderRadius: 16, marginBottom: 4, fontSize: 12 }}>
+                <span>↩</span><span>{b.label}</span>
+              </div>
+            ))}
+          </div>
+        );
+      }
+
+      if (pType === "list" || pType === "product_list") {
+        const title = (payload?.text as string) ?? (payload?.bodyText as string) ?? text;
+        const sections = (payload?.sections as Array<{ title?: string; rows?: Array<{ id: string; title: string; description?: string }> }>) ?? [];
+        const items = sections.flatMap((s) => s.rows ?? []);
+        return (
+          <div style={{ fontSize: 13 }}>
+            {title && <p style={{ margin: "0 0 8px" }}>{renderFormattedText(title, `list-${msg.id}`)}</p>}
+            {items.map((item) => (
+              <div key={item.id} style={{ padding: "5px 8px", background: "rgba(0,0,0,0.07)", borderRadius: 6, marginBottom: 4 }}>
+                <div style={{ fontWeight: 600 }}>{item.title}</div>
+                {item.description && <div style={{ fontSize: 11, opacity: 0.7 }}>{item.description}</div>}
+              </div>
+            ))}
+          </div>
+        );
+      }
+
+      if (pType === "poll") {
+        const question = (payload?.question as string) ?? text;
+        const options = (payload?.options as string[]) ?? [];
+        return (
+          <div style={{ fontSize: 13 }}>
+            <div style={{ display: "flex", gap: 6, alignItems: "center", marginBottom: 6 }}>
+              <span>📊</span><strong>{question}</strong>
+            </div>
+            {options.map((opt, i) => (
+              <div key={i} style={{ padding: "5px 10px", background: "rgba(0,0,0,0.07)", borderRadius: 16, marginBottom: 4 }}>{opt}</div>
+            ))}
+          </div>
+        );
+      }
+
+      return <span style={{ whiteSpace: "pre-wrap", fontSize: 13 }}>{renderFormattedText(text, `txt-${msg.id}`)}</span>;
+    }
   }
 }
 
-export function MessageBubble({ message, isFirst, showAvatar, convPhone, onRetry, quotedMessage }: Props) {
+// ─── MessageBubble ────────────────────────────────────────────────────────────
+
+export function MessageBubble({ message, isFirst, showAvatar, convPhone, contactName, onRetry, onReply, quotedMessage }: Props) {
+  const [copied, setCopied] = useState(false);
+  const [showInfo, setShowInfo] = useState(false);
+
   const isOutbound = message.direction === "outbound";
   const isPrivate = message.is_private;
   const isActivity = message.content_type === "activity";
-  const avatarColor = getAvatarColor(convPhone);
+  const avatarColor = getNameAvatarColor(contactName, convPhone);
+  const avatarInitials = getNameInitials(contactName, convPhone);
+
+  const isAi = isOutbound && Boolean(message.ai_model);
+  const isManual = isOutbound && !isAi && Boolean(message.sender_name);
+  const isFlow = isOutbound && !isAi && !isManual;
+  const isTemplate = message.content_type === "template" ||
+    Boolean((message.payload_json as Record<string, unknown> | null)?.templateName) ||
+    (message.payload_json as Record<string, unknown> | null)?.type === "template";
+  const isFailed = message.delivery_status === "failed";
+
+  function handleCopy() {
+    void navigator.clipboard.writeText(message.message_text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
 
   if (isActivity) {
     return (
@@ -96,33 +379,99 @@ export function MessageBubble({ message, isFirst, showAvatar, convPhone, onRetry
     );
   }
 
-  const bubbleClass = isPrivate ? "private" : isOutbound ? "outbound" : "inbound";
-  const groupClass = isFirst ? " iv-bubble-group-first" : "";
+  const bubbleClass = [
+    "iv-bubble",
+    isPrivate ? "private" : isOutbound ? "outbound" : "inbound",
+    isAi ? "iv-bubble-ai" : "",
+    isFlow ? "iv-bubble-flow" : "",
+    isFailed ? "iv-bubble-failed" : "",
+    isFirst ? "iv-bubble-group-first" : ""
+  ].filter(Boolean).join(" ");
 
   return (
     <div className={`iv-msg-row${isOutbound ? " outbound" : ""}`}>
       {!isOutbound && (
         showAvatar
           ? <div className={`iv-msg-avatar-sm iv-avatar av-${avatarColor}`} style={{ fontSize: 8 }}>
-              {convPhone.replace(/\D/g, "").slice(-2)}
+              {avatarInitials}
             </div>
           : <div className="iv-msg-avatar-space" />
       )}
 
-      <div className={`iv-bubble ${bubbleClass}${groupClass}`}>
+      <div className={bubbleClass} style={{ position: "relative" }}>
         {isPrivate && (
           <div className="iv-bubble-private-label">🔒 Private Note</div>
         )}
         {quotedMessage && (
           <div className="iv-reply-quote">
-            {quotedMessage.message_text.slice(0, 100)}
+            {renderFormattedText((quotedMessage.message_text ?? "").slice(0, 120), `quote-${message.id}`)}
           </div>
         )}
+
         {renderContent(message)}
-        <div className="iv-bubble-footer">
+
+        {/* Meta row: badges + sender + time + delivery + actions */}
+        <div className="iv-bubble-meta">
+          {isAi && <span className="iv-badge iv-badge-ai">AI</span>}
+          {isFlow && <span className="iv-badge iv-badge-flow">Flow</span>}
+          {isTemplate && <span className="iv-badge iv-badge-template">Template</span>}
+          {isManual && message.sender_name && (
+            <span className="iv-bubble-sender">{message.sender_name}</span>
+          )}
           {isFirst && <span className="iv-bubble-time">{formatTime(message.created_at)}</span>}
           {isOutbound && renderDelivery(message.delivery_status, message.retry_count, () => onRetry?.(message.id))}
+          {onReply && (
+            <button className="iv-reply-btn" title="Reply" onClick={() => onReply(message)}>
+              ↩
+            </button>
+          )}
+          <button className="iv-copy-btn" title={copied ? "Copied!" : "Copy"} onClick={handleCopy}>
+            {copied ? "✓" : "⎘"}
+          </button>
+          {isOutbound && (
+            <button
+              className={`iv-info-btn${isFailed ? " iv-info-btn-error" : ""}`}
+              title={isFailed ? "Delivery failed — click for details" : "Message info"}
+              onClick={() => setShowInfo((v) => !v)}
+            >
+              ⓘ
+            </button>
+          )}
         </div>
+
+        {/* Inline error hint (always visible on failed) */}
+        {isFailed && (
+          <div className="iv-bubble-error-hint">
+            <span className="iv-bubble-error-hint-icon">⚠</span>
+            <span className="iv-bubble-error-hint-text">
+              {message.error_code ? `Error ${message.error_code}: ` : ""}
+              {message.error_message ?? "Message delivery failed"}
+            </span>
+          </div>
+        )}
+
+        {/* Info popover (toggle) */}
+        {showInfo && (
+          <div className="iv-info-popover">
+            {message.error_code && (
+              <div className="iv-info-row"><strong>Error {message.error_code}</strong></div>
+            )}
+            {message.error_message && (
+              <div className="iv-info-row iv-info-errmsg">{message.error_message}</div>
+            )}
+            {message.error_code && META_ERROR_SOLUTIONS[message.error_code] && (
+              <div className="iv-info-row iv-info-fix">
+                <strong>Fix:</strong> {META_ERROR_SOLUTIONS[message.error_code]}
+              </div>
+            )}
+            {!message.error_code && (
+              <div className="iv-info-row">Status: {message.delivery_status}</div>
+            )}
+            <div className="iv-info-row iv-info-ts">
+              {new Date(message.created_at).toLocaleString()}
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/modules/dashboard/inbox-v2/components/MessageThread.tsx
+++ b/apps/web/src/modules/dashboard/inbox-v2/components/MessageThread.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef, useCallback, useState, useMemo } from "react";
 import { differenceInSeconds } from "date-fns";
 import { useConvStore, type ConversationMessage } from "../store/convStore";
-import { useMessages, useMarkRead, useSetStatus, useRetryMessage } from "../queries";
+import { useMessages, useMarkRead, useSetStatus, useRetryMessage, useNotes } from "../queries";
 import { MessageBubble } from "./MessageBubble";
 import { TypingIndicator } from "./TypingIndicator";
 import { ComposeArea } from "./ComposeArea";
-import { getAvatarColor } from "./ConversationRow";
+import { getNameAvatarColor, getNameInitials } from "./ConversationRow";
 
 function shouldGroup(prev: ConversationMessage, curr: ConversationMessage): boolean {
   return (
@@ -18,23 +18,55 @@ function shouldGroup(prev: ConversationMessage, curr: ConversationMessage): bool
   );
 }
 
+function isSameDay(a: string, b: string): boolean {
+  return new Date(Date.parse(a)).toDateString() === new Date(Date.parse(b)).toDateString();
+}
+
+function formatDateLabel(value: string): string {
+  const d = new Date(Date.parse(value));
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  if (d.toDateString() === today.toDateString()) return "Today";
+  if (d.toDateString() === yesterday.toDateString()) return "Yesterday";
+  return d.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: d.getFullYear() !== today.getFullYear() ? "numeric" : undefined
+  });
+}
+
 interface Props {
   convId: string;
   optimisticMap: React.MutableRefObject<Map<string, string>>;
 }
 
 export function MessageThread({ convId, optimisticMap }: Props) {
-  const { byId, messagesByConvId, typingState } = useConvStore();
+  const { byId, messagesByConvId, notesByConvId, typingState } = useConvStore();
   const conv = byId[convId];
-  const messages = messagesByConvId[convId] ?? [];
+
+  const messages = useMemo(() => {
+    const msgs = messagesByConvId[convId] ?? [];
+    const notes = notesByConvId[convId] ?? [];
+    if (notes.length === 0) return msgs;
+    const noteIds = new Set(notes.map((n) => n.id));
+    const deduped = msgs.filter((m) => !noteIds.has(m.id));
+    return [...deduped, ...notes].sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at));
+  }, [messagesByConvId, notesByConvId, convId]);
   const bottomRef = useRef<HTMLDivElement>(null);
   const isAtBottomRef = useRef(true);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const [showFab, setShowFab] = useState(false);
 
-  useMessages(convId);
+  const messagesQuery = useMessages(convId);
+  useNotes(convId);
   const markRead = useMarkRead();
   const setStatus = useSetStatus();
   const retryMsg = useRetryMessage();
+  const [replyToMsg, setReplyToMsg] = useState<ConversationMessage | null>(null);
+  const [showSuggestion, setShowSuggestion] = useState(true);
+  useEffect(() => setShowSuggestion(true), [convId]);
 
   useEffect(() => {
     void markRead.mutateAsync(convId).catch(() => undefined);
@@ -47,15 +79,30 @@ export function MessageThread({ convId, optimisticMap }: Props) {
     }
   }, [messages.length]);
 
+  const scrollToBottom = useCallback(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    setShowFab(false);
+  }, []);
+
   const handleScroll = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
-    isAtBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+    isAtBottomRef.current = atBottom;
+    setShowFab(!atBottom);
   }, []);
 
   const handleRetry = useCallback((msgId: string) => {
     void retryMsg.mutateAsync({ convId, msgId });
   }, [convId, retryMsg]);
+
+  const handleReply = useCallback((msg: ConversationMessage) => {
+    setReplyToMsg(msg);
+  }, []);
+
+  const handleLoadOlder = useCallback(() => {
+    void messagesQuery.fetchNextPage();
+  }, [messagesQuery]);
 
   if (!conv) {
     return (
@@ -65,17 +112,24 @@ export function MessageThread({ convId, optimisticMap }: Props) {
     );
   }
 
-  const avatarColor = getAvatarColor(conv.phone_number);
+  const avatarColor = getNameAvatarColor(conv.contact_name, conv.phone_number);
+  const scoreBand = conv.score >= 70 ? "hot" : conv.score >= 40 ? "warm" : "cold";
+  const SUGGESTIONS = {
+    hot:  { icon: "🚀", label: "Hot lead",  tip: "Reply with pricing or a booking link" },
+    warm: { icon: "💬", label: "Warm lead", tip: "Qualify budget and timeline" },
+    cold: { icon: "📧", label: "Cold lead", tip: "Nurture with educational content" },
+  } as const;
+  const suggestion = SUGGESTIONS[scoreBand];
 
   return (
     <div className="iv-thread">
       {/* Header */}
       <div className="iv-thread-header">
         <div className={`iv-avatar av-${avatarColor}`} style={{ width: 36, height: 36, fontSize: 11, flexShrink: 0 }}>
-          {conv.phone_number.replace(/\D/g, "").slice(-2)}
+          {getNameInitials(conv.contact_name, conv.phone_number)}
         </div>
         <div>
-          <div className="iv-thread-name">{conv.phone_number}</div>
+          <div className="iv-thread-name">{conv.contact_name || conv.phone_number}</div>
           <div className="iv-thread-meta">{conv.channel_type === "api" ? "WhatsApp API" : conv.channel_type === "web" ? "Web Widget" : "WhatsApp QR"}</div>
         </div>
         <div className="iv-thread-actions">
@@ -92,8 +146,43 @@ export function MessageThread({ convId, optimisticMap }: Props) {
         </div>
       </div>
 
+      {/* Tags bar */}
+      <div className="iv-thread-tags">
+        <span className={`iv-thread-tag ${conv.ai_paused ? "iv-tag-paused" : "iv-tag-ai"}`}>
+          {conv.ai_paused ? "⏸ AI Paused" : "🤖 AI Active"}
+        </span>
+        <span className={`iv-thread-tag iv-tag-score-${scoreBand}`}>
+          {scoreBand === "hot" ? "🔥" : scoreBand === "warm" ? "☀️" : "❄️"} {scoreBand.charAt(0).toUpperCase() + scoreBand.slice(1)}
+        </span>
+        {conv.priority !== "none" && (
+          <span className={`iv-thread-tag iv-priority-pill iv-priority-${conv.priority}`}>{conv.priority}</span>
+        )}
+        <span className={`iv-thread-tag iv-status-pill iv-status-${conv.status ?? "open"}`}>{conv.status ?? "open"}</span>
+      </div>
+
+      {/* Reply suggestion banner */}
+      {showSuggestion && conv.score > 0 && (
+        <div className="iv-reply-suggestion">
+          <span>{suggestion.icon} <strong>{suggestion.label}</strong> — {suggestion.tip}</span>
+          <button className="iv-reply-suggestion-close" onClick={() => setShowSuggestion(false)}>✕</button>
+        </div>
+      )}
+
       {/* Messages area */}
-      <div className="iv-messages-area" ref={scrollRef} onScroll={handleScroll}>
+      <div className="iv-messages-area" ref={scrollRef} onScroll={handleScroll} style={{ position: "relative" }}>
+        {/* Load older messages */}
+        {messagesQuery.hasNextPage && (
+          <div className="iv-load-older">
+            <button
+              className="iv-load-older-btn"
+              onClick={handleLoadOlder}
+              disabled={messagesQuery.isFetchingNextPage}
+            >
+              {messagesQuery.isFetchingNextPage ? "Loading…" : "Load older messages"}
+            </button>
+          </div>
+        )}
+
         {messages.map((msg, i) => {
           const prev = messages[i - 1];
           const next = messages[i + 1];
@@ -103,17 +192,26 @@ export function MessageThread({ convId, optimisticMap }: Props) {
           const quoted = msg.in_reply_to_id
             ? messages.find((m) => m.id === msg.in_reply_to_id) ?? null
             : null;
+          const showDate = !prev || !isSameDay(prev.created_at, msg.created_at);
 
           return (
-            <MessageBubble
-              key={msg.id}
-              message={msg}
-              isFirst={isFirst}
-              showAvatar={showAvatar}
-              convPhone={conv.phone_number}
-              onRetry={handleRetry}
-              quotedMessage={quoted}
-            />
+            <div key={msg.id}>
+              {showDate && (
+                <div className="iv-date-separator">
+                  <span>{formatDateLabel(msg.created_at)}</span>
+                </div>
+              )}
+              <MessageBubble
+                message={msg}
+                isFirst={isFirst}
+                showAvatar={showAvatar}
+                convPhone={conv.phone_number}
+                contactName={conv.contact_name}
+                onRetry={handleRetry}
+                onReply={handleReply}
+                quotedMessage={quoted}
+              />
+            </div>
           );
         })}
 
@@ -121,8 +219,15 @@ export function MessageThread({ convId, optimisticMap }: Props) {
         <div ref={bottomRef} />
       </div>
 
+      {/* Scroll to bottom FAB */}
+      {showFab && (
+        <button className="iv-scroll-fab" onClick={scrollToBottom} title="Scroll to latest">
+          ↓
+        </button>
+      )}
+
       {/* Compose */}
-      <ComposeArea convId={convId} optimisticMap={optimisticMap} />
+      <ComposeArea convId={convId} optimisticMap={optimisticMap} replyToMsg={replyToMsg} onClearReply={() => setReplyToMsg(null)} />
     </div>
   );
 }

--- a/apps/web/src/modules/dashboard/inbox-v2/components/NewConvModal.tsx
+++ b/apps/web/src/modules/dashboard/inbox-v2/components/NewConvModal.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { useAuth } from "../../../../lib/auth-context";
+import { createOutboundConversation } from "../api";
+
+interface Props {
+  onClose: () => void;
+  onCreated: (convId: string) => void;
+}
+
+export function NewConvModal({ onClose, onCreated }: Props) {
+  const { token } = useAuth();
+  const [phone, setPhone] = useState("");
+  const [channelType, setChannelType] = useState<"api" | "qr">("api");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleCreate = async () => {
+    const trimPhone = phone.trim();
+    if (!trimPhone) { setError("Phone number is required"); return; }
+    setLoading(true); setError("");
+    try {
+      const result = await createOutboundConversation(token!, { phone: trimPhone, channelType, initialMessage: message.trim() || undefined });
+      onCreated(result.conversationId);
+      onClose();
+    } catch (e) {
+      setError((e as Error).message);
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="iv-modal-overlay" onClick={onClose}>
+      <div className="iv-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="iv-tvd-head">
+          <strong>New Conversation</strong>
+          <button className="iv-tvd-close" onClick={onClose}>✕</button>
+        </div>
+        <div style={{ padding: "14px 16px", display: "flex", flexDirection: "column", gap: 12 }}>
+          <div>
+            <div className="iv-tvd-label">Phone Number</div>
+            <input
+              className="iv-tvd-input"
+              style={{ width: "100%", boxSizing: "border-box" }}
+              placeholder="+1234567890"
+              value={phone}
+              autoFocus
+              onChange={(e) => setPhone(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") void handleCreate(); }}
+            />
+          </div>
+          <div>
+            <div className="iv-tvd-label">Channel</div>
+            <select
+              style={{ width: "100%", height: 36, border: "1.5px solid #e2eaf4", borderRadius: 8, padding: "0 10px", fontSize: 13, fontFamily: "Manrope, sans-serif", outline: "none", background: "#fff" }}
+              value={channelType}
+              onChange={(e) => setChannelType(e.target.value as "api" | "qr")}
+            >
+              <option value="api">WhatsApp API</option>
+              <option value="qr">WhatsApp QR</option>
+            </select>
+          </div>
+          <div>
+            <div className="iv-tvd-label">Initial Message (optional)</div>
+            <textarea
+              style={{ width: "100%", boxSizing: "border-box", height: 72, resize: "vertical", border: "1.5px solid #e2eaf4", borderRadius: 8, padding: "8px 10px", fontSize: 13, fontFamily: "Manrope, sans-serif", outline: "none", background: "#fff" }}
+              placeholder="Hi, I wanted to reach out…"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+            />
+          </div>
+          {error && <div style={{ fontSize: 12, color: "#ef4444" }}>{error}</div>}
+        </div>
+        <div className="iv-tvd-footer">
+          <button className="iv-tvd-cancel" onClick={onClose}>Cancel</button>
+          <button className="iv-tvd-send" disabled={loading} onClick={() => void handleCreate()}>
+            {loading ? "Creating…" : "Start Conversation"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/modules/dashboard/inbox-v2/hooks/useRealtimeSocket.ts
+++ b/apps/web/src/modules/dashboard/inbox-v2/hooks/useRealtimeSocket.ts
@@ -106,7 +106,7 @@ export function useRealtimeSocket(token: string | null) {
               direction: message.direction as "inbound" | "outbound",
               delivery_status: message.delivery_status as import("../store/convStore").MsgDeliveryStatus,
               content_type: (message.content_type ?? "text") as import("../store/convStore").MsgContentType,
-              payload_json: null
+              payload_json: (message as unknown as { payload_json?: Record<string, unknown> }).payload_json ?? null
             });
             optimisticMap.current.delete(message.echo_id!);
           } else if (!s.messagesByConvId[conversationId]?.some((m) => m.id === message.id)) {
@@ -115,7 +115,7 @@ export function useRealtimeSocket(token: string | null) {
               direction: message.direction as "inbound" | "outbound",
               delivery_status: message.delivery_status as import("../store/convStore").MsgDeliveryStatus,
               content_type: (message.content_type ?? "text") as import("../store/convStore").MsgContentType,
-              payload_json: null
+              payload_json: (message as unknown as { payload_json?: Record<string, unknown> }).payload_json ?? null
             });
           }
           break;
@@ -134,6 +134,7 @@ export function useRealtimeSocket(token: string | null) {
             agent_last_seen_at: null,
             unread_count: 0,
             phone_number: "",
+            contact_name: null,
             stage: "",
             score: 0,
             lead_kind: "lead",
@@ -152,9 +153,17 @@ export function useRealtimeSocket(token: string | null) {
           break;
         case "conversation.updated":
         case "conversation.status_changed":
-        case "conversation.priority_changed":
-          s.upsertConv(envelope.data as Partial<import("../store/convStore").Conversation> & { id: string });
+        case "conversation.priority_changed": {
+          const raw = envelope.data;
+          if (!s.byId[raw.id]) break; // ignore events for convs not in store (incomplete data)
+          const lm = (raw as { last_message?: { text: string; sent_at: string } }).last_message;
+          s.upsertConv({
+            ...raw,
+            last_message: lm ? lm.text : (raw as unknown as { last_message?: string }).last_message,
+            last_message_at: lm ? lm.sent_at : undefined,
+          } as Partial<import("../store/convStore").Conversation> & { id: string });
           break;
+        }
         case "conversation.read":
           s.clearUnread(envelope.data.conversation_id);
           break;
@@ -167,16 +176,19 @@ export function useRealtimeSocket(token: string | null) {
         case "conversations.bulk_updated": {
           const { ids, action } = envelope.data;
           for (const id of ids) {
+            if (!s.byId[id]) continue;
             if (action === "resolve") s.upsertConv({ id, status: "resolved" as import("../store/convStore").ConvStatus });
             else if (action === "reopen") s.upsertConv({ id, status: "open" as import("../store/convStore").ConvStatus });
           }
           break;
         }
         case "conversation.label_changed":
-          s.upsertConv({ id: envelope.data.id, label_ids: envelope.data.label_ids });
+          if (s.byId[envelope.data.id])
+            s.upsertConv({ id: envelope.data.id, label_ids: envelope.data.label_ids });
           break;
         case "conversation.assigned":
-          s.upsertConv({ id: envelope.data.id, assigned_agent_profile_id: envelope.data.agent_id });
+          if (s.byId[envelope.data.id])
+            s.upsertConv({ id: envelope.data.id, assigned_agent_profile_id: envelope.data.agent_id });
           break;
         case "contact.updated":
           // Invalidate contact query so sidebar refetches updated info

--- a/apps/web/src/modules/dashboard/inbox-v2/inbox-v2.css
+++ b/apps/web/src/modules/dashboard/inbox-v2/inbox-v2.css
@@ -937,3 +937,295 @@
 }
 .cd-input:focus { border-color: #2563eb; }
 select.cd-input { height: 36px; }
+
+/* ── Date Separator ──────────────────────────────────────────────────────── */
+.iv-date-separator {
+  display: flex; align-items: center; justify-content: center;
+  padding: 8px 16px; gap: 8px;
+}
+.iv-date-separator::before, .iv-date-separator::after {
+  content: ""; flex: 1; height: 1px; background: #e2eaf4;
+}
+.iv-date-separator span {
+  font-size: 11px; font-weight: 600; color: #94a3b8;
+  background: #f8fafc; padding: 2px 10px; border-radius: 12px;
+  border: 1px solid #e2eaf4; white-space: nowrap;
+}
+
+/* ── Load Older Messages ─────────────────────────────────────────────────── */
+.iv-load-older {
+  display: flex; justify-content: center; padding: 10px 0;
+}
+.iv-load-older-btn {
+  font-size: 12px; color: #2563eb; background: none; border: 1px solid #2563eb;
+  border-radius: 16px; padding: 4px 14px; cursor: pointer; transition: background 120ms;
+}
+.iv-load-older-btn:hover { background: #eff6ff; }
+.iv-load-older-btn:disabled { opacity: 0.5; cursor: default; }
+
+/* ── Scroll-to-bottom FAB ────────────────────────────────────────────────── */
+.iv-scroll-fab {
+  position: absolute; bottom: 72px; right: 18px;
+  width: 36px; height: 36px; border-radius: 50%;
+  background: #2563eb; color: #fff; border: none;
+  font-size: 16px; cursor: pointer; box-shadow: 0 2px 8px rgba(37,99,235,0.35);
+  display: flex; align-items: center; justify-content: center;
+  transition: transform 120ms, box-shadow 120ms; z-index: 10;
+}
+.iv-scroll-fab:hover { transform: translateY(-1px); box-shadow: 0 4px 12px rgba(37,99,235,0.4); }
+
+/* ── Copy button on message bubble ──────────────────────────────────────── */
+.iv-copy-btn {
+  background: none; border: none; cursor: pointer; color: inherit; opacity: 0;
+  font-size: 12px; padding: 0 2px; line-height: 1; transition: opacity 120ms;
+  margin-left: auto;
+}
+.iv-bubble:hover .iv-copy-btn { opacity: 0.5; }
+.iv-bubble:hover .iv-copy-btn:hover { opacity: 1; }
+
+/* ── Meta error block ────────────────────────────────────────────────────── */
+.iv-meta-error {
+  margin-top: 4px; padding: 6px 8px;
+  background: rgba(239,68,68,0.08); border-radius: 6px;
+  border-left: 3px solid #ef4444;
+  font-size: 11.5px; color: #b91c1c;
+}
+.iv-meta-error-msg { opacity: 0.75; margin-bottom: 2px; }
+.iv-meta-error-fix { color: #1d4ed8; }
+.iv-meta-error-fix strong { margin-right: 3px; }
+
+/* ── File attachment strip ───────────────────────────────────────────────── */
+.iv-attachment-strip {
+  display: flex; gap: 6px; flex-wrap: wrap;
+  padding: 6px 12px; border-bottom: 1px solid #f1f5f9;
+}
+.iv-attachment-thumb {
+  position: relative; width: 64px;
+  display: flex; flex-direction: column; align-items: center; gap: 2px;
+}
+.iv-attachment-thumb img {
+  width: 56px; height: 56px; object-fit: cover; border-radius: 6px;
+  border: 1px solid #e2eaf4;
+}
+.iv-attachment-file-icon { font-size: 32px; line-height: 1; }
+.iv-attachment-name {
+  font-size: 9px; color: #64748b; white-space: nowrap; overflow: hidden;
+  text-overflow: ellipsis; max-width: 62px; text-align: center;
+}
+.iv-attachment-remove {
+  position: absolute; top: -4px; right: -4px;
+  width: 16px; height: 16px; border-radius: 50%;
+  background: #ef4444; color: #fff; border: none;
+  font-size: 9px; cursor: pointer; display: flex; align-items: center; justify-content: center;
+}
+
+/* ── Emoji picker ────────────────────────────────────────────────────────── */
+.iv-emoji-picker {
+  position: absolute; bottom: 40px; left: 0;
+  background: #fff; border: 1px solid #e2eaf4; border-radius: 10px;
+  padding: 8px; display: flex; flex-wrap: wrap; gap: 2px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.1); z-index: 30; width: 200px;
+}
+.iv-emoji-btn {
+  font-size: 20px; background: none; border: none; cursor: pointer;
+  padding: 4px; border-radius: 6px; transition: background 80ms;
+  line-height: 1;
+}
+.iv-emoji-btn:hover { background: #f1f5f9; }
+
+/* ── Char counter ────────────────────────────────────────────────────────── */
+.iv-char-counter {
+  font-size: 10.5px; text-align: right; padding: 1px 12px 3px;
+}
+
+/* ── Score chip on conversation row ─────────────────────────────────────── */
+.iv-score-chip {
+  font-size: 9.5px; font-weight: 700; padding: 1px 5px; border-radius: 8px;
+  line-height: 1.3; flex-shrink: 0;
+}
+.iv-score-hot { background: #fee2e2; color: #b91c1c; }
+.iv-score-warm { background: #fef3c7; color: #92400e; }
+.iv-score-cold { background: #f1f5f9; color: #475569; }
+
+/* ── Sender badges ────────────────────────────────────────────────────────── */
+.iv-badge {
+  font-size: 9px; font-weight: 700; padding: 1px 5px; border-radius: 6px;
+  letter-spacing: 0.03em; text-transform: uppercase; flex-shrink: 0;
+}
+.iv-badge-ai   { background: #ede9fe; color: #6d28d9; }
+.iv-badge-flow { background: #d1fae5; color: #065f46; }
+.iv-badge-template { background: #dbeafe; color: #1e40af; }
+
+/* ── Bubble meta row ─────────────────────────────────────────────────────── */
+.iv-bubble-meta {
+  display: flex; align-items: center; gap: 5px; flex-wrap: wrap;
+  margin-top: 4px; font-size: 10.5px; color: rgba(255,255,255,0.6);
+}
+.iv-bubble.inbound .iv-bubble-meta { color: rgba(0,0,0,0.45); }
+.iv-bubble-sender { font-size: 10.5px; font-weight: 600; }
+.iv-token-count { font-size: 9.5px; opacity: 0.55; }
+
+/* ── Bubble variants for AI / Flow ──────────────────────────────────────── */
+.iv-bubble.iv-bubble-ai   { border-left: 2px solid #8b5cf6; }
+.iv-bubble.iv-bubble-flow { border-left: 2px solid #10b981; }
+.iv-bubble.iv-bubble-failed { border-left: 2px solid #ef4444; }
+
+/* ── Inline error hint ───────────────────────────────────────────────────── */
+.iv-bubble-error-hint {
+  display: flex; align-items: flex-start; gap: 5px;
+  margin-top: 5px; font-size: 11px;
+  color: #fca5a5; /* light red for dark outbound bubble */
+}
+.iv-bubble.inbound .iv-bubble-error-hint { color: #b91c1c; }
+.iv-bubble-error-hint-icon { flex-shrink: 0; }
+.iv-bubble-error-hint-text { line-height: 1.4; }
+
+/* ── Info button ─────────────────────────────────────────────────────────── */
+.iv-info-btn {
+  background: none; border: none; cursor: pointer; color: inherit;
+  opacity: 0.4; font-size: 13px; padding: 0 1px; line-height: 1;
+  transition: opacity 120ms; margin-left: 2px;
+}
+.iv-info-btn:hover { opacity: 0.85; }
+.iv-info-btn-error { opacity: 0.8; color: #fca5a5; }
+.iv-bubble.inbound .iv-info-btn-error { color: #ef4444; }
+
+/* ── Info popover ────────────────────────────────────────────────────────── */
+.iv-info-popover {
+  margin-top: 6px; padding: 8px 10px;
+  background: rgba(0,0,0,0.18); border-radius: 8px;
+  font-size: 11.5px; display: flex; flex-direction: column; gap: 3px;
+}
+.iv-bubble.inbound .iv-info-popover { background: #f1f5f9; color: #1e293b; }
+.iv-info-row { line-height: 1.4; }
+.iv-info-errmsg { opacity: 0.75; }
+.iv-info-fix { color: #93c5fd; }
+.iv-bubble.inbound .iv-info-fix { color: #2563eb; }
+.iv-info-ts { opacity: 0.5; font-size: 10.5px; }
+
+/* ── Reply button on bubble ──────────────────────────────────────────────── */
+.iv-reply-btn {
+  background: none; border: none; cursor: pointer; color: inherit;
+  opacity: 0; font-size: 13px; padding: 0 2px; line-height: 1;
+  transition: opacity 120ms; margin-left: 2px;
+}
+.iv-bubble:hover .iv-reply-btn { opacity: 0.55; }
+.iv-reply-btn:hover { opacity: 1 !important; }
+
+/* ── Reply-to strip in ComposeArea ──────────────────────────────────────── */
+.iv-reply-to-strip {
+  display: flex; align-items: center; gap: 6px;
+  padding: 5px 10px; background: #f0f9ff;
+  border-left: 3px solid #38bdf8; font-size: 12px;
+  color: #0369a1; border-radius: 0 4px 4px 0; margin: 0 2px 2px;
+}
+.iv-reply-to-icon { font-size: 13px; flex-shrink: 0; }
+.iv-reply-to-text { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.iv-reply-to-clear {
+  background: none; border: none; cursor: pointer;
+  color: #64748b; font-size: 12px; padding: 0 2px; flex-shrink: 0;
+}
+.iv-reply-to-clear:hover { color: #ef4444; }
+
+/* ── Thread tags bar ────────────────────────────────────────────────────── */
+.iv-thread-tags {
+  display: flex; flex-wrap: wrap; gap: 5px; align-items: center;
+  padding: 5px 16px; border-bottom: 1px solid #f1f5f9; flex-shrink: 0;
+  background: #fafbfd;
+}
+.iv-thread-tag {
+  padding: 2px 8px; border-radius: 999px;
+  font-size: 10.5px; font-weight: 700; white-space: nowrap;
+  border: 1px solid transparent;
+}
+.iv-tag-ai     { background: #d1fae5; color: #065f46; border-color: #a7f3d0; }
+.iv-tag-paused { background: #fef3c7; color: #92400e; border-color: #fde68a; }
+.iv-tag-score-hot  { background: #fee2e2; color: #b91c1c; border-color: #fecdd3; }
+.iv-tag-score-warm { background: #fef3c7; color: #92400e; border-color: #fde68a; }
+.iv-tag-score-cold { background: #f1f5f9; color: #475569; border-color: #e2eaf4; }
+
+/* ── Reply suggestion banner ─────────────────────────────────────────────── */
+.iv-reply-suggestion {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 7px 16px; background: #f0f4ff; border-bottom: 1px solid #c7d6f7;
+  font-size: 12px; color: #334155; flex-shrink: 0;
+}
+.iv-reply-suggestion strong { color: #1d4ed8; }
+.iv-reply-suggestion-close {
+  background: none; border: none; cursor: pointer; color: #94a3b8;
+  font-size: 13px; padding: 0 2px; line-height: 1; flex-shrink: 0;
+}
+.iv-reply-suggestion-close:hover { color: #475569; }
+
+/* ── Bulk action bar ─────────────────────────────────────────────────────── */
+.iv-bulk-bar {
+  display: flex; align-items: center; gap: 6px;
+  padding: 6px 12px; background: #f0f4ff; border-bottom: 1px solid #c7d6f7;
+  flex-shrink: 0;
+}
+.iv-bulk-count { font-size: 12px; font-weight: 700; color: #1d4ed8; flex: 1; }
+.iv-bulk-btn {
+  height: 26px; padding: 0 10px; border: 1px solid #c7d6f7; border-radius: 6px;
+  background: #fff; font-size: 11.5px; font-weight: 600; color: #334155; cursor: pointer;
+  transition: background 80ms; font-family: "Manrope", sans-serif;
+}
+.iv-bulk-btn:hover:not(:disabled) { background: #eff6ff; color: #1d4ed8; }
+.iv-bulk-btn:disabled { opacity: 0.5; cursor: default; }
+.iv-bulk-cancel { color: #5f6f86; }
+
+/* ── Conversation row checkbox ───────────────────────────────────────────── */
+.iv-crow-check {
+  display: flex; align-items: center; justify-content: center;
+  width: 18px; height: 100%; flex-shrink: 0; cursor: pointer; padding-top: 2px;
+}
+.iv-checkbox {
+  width: 14px; height: 14px; border-radius: 4px; border: 2px solid #c7d6f7;
+  background: #fff; transition: all 80ms; flex-shrink: 0;
+}
+.iv-checkbox.checked {
+  background: #2563eb; border-color: #2563eb;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 8'%3E%3Cpath d='M1 4l2.5 2.5L9 1' stroke='%23fff' stroke-width='1.8' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat; background-position: center; background-size: 10px;
+}
+.iv-crow.selected { background: #eff6ff; }
+.iv-crow.selected .iv-crow-check .iv-checkbox { border-color: #2563eb; }
+
+/* ── Modal overlay + container ───────────────────────────────────────────── */
+.iv-modal-overlay {
+  position: fixed; inset: 0; background: rgba(0,0,0,0.35); z-index: 200;
+  display: flex; align-items: center; justify-content: center;
+}
+.iv-modal {
+  background: #fff; border-radius: 14px; width: 440px; max-width: 92vw;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.18); overflow: hidden;
+  max-height: 82vh; display: flex; flex-direction: column;
+}
+.iv-modal-lg { width: 560px; }
+
+/* ── Canned manage rows ──────────────────────────────────────────────────── */
+.iv-canned-manage-row {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 10px; border-radius: 8px; border: 1px solid #f1f5f9;
+  transition: background 80ms;
+}
+.iv-canned-manage-row:hover { background: #fafbfd; }
+.iv-canned-edit-row {
+  padding: 10px 12px; border-radius: 8px; border: 1px solid #c7d6f7;
+  background: #f0f4ff; display: flex; flex-direction: column; gap: 4px;
+}
+
+/* ── Timeline ────────────────────────────────────────────────────────────── */
+.iv-timeline { display: flex; flex-direction: column; gap: 0; }
+.iv-timeline-item {
+  display: flex; align-items: flex-start; gap: 8px; padding: 5px 0;
+  border-left: 2px solid #e2eaf4; margin-left: 10px; padding-left: 14px;
+  position: relative;
+}
+.iv-timeline-item:last-child { border-left-color: transparent; }
+.iv-timeline-icon {
+  font-size: 13px; position: absolute; left: -10px; top: 4px;
+  background: #fff; line-height: 1;
+}
+.iv-timeline-body { display: flex; flex-direction: column; gap: 1px; }
+.iv-timeline-label { font-size: 12px; font-weight: 600; color: #334155; }
+.iv-timeline-time  { font-size: 10.5px; color: #94a3b8; }

--- a/apps/web/src/modules/dashboard/inbox-v2/queries.ts
+++ b/apps/web/src/modules/dashboard/inbox-v2/queries.ts
@@ -14,8 +14,12 @@ import {
   postRetry,
   postBulk,
   fetchConvSearch,
-  type SendMessageParams
+  fetchConvNotes,
+  createConvNote,
+  type SendMessageParams,
+  type ConvNote
 } from "./api";
+import type { ConversationMessage } from "./store/convStore";
 
 // ── Conversations ─────────────────────────────────────────────────────────
 
@@ -137,5 +141,58 @@ export function useBulkAction() {
     mutationFn: ({ ids, action, payload }: { ids: string[]; action: string; payload?: Record<string, unknown> }) =>
       postBulk(token!, ids, action, payload),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["iv2-convs"] })
+  });
+}
+
+// ── Notes ─────────────────────────────────────────────────────────────────────
+
+function noteToMessage(note: ConvNote, convId: string): ConversationMessage {
+  return {
+    id: `note-${note.id}`,
+    conversation_id: convId,
+    direction: "outbound",
+    sender_name: note.sender_name,
+    message_text: note.content,
+    content_type: "text",
+    is_private: true,
+    in_reply_to_id: null,
+    echo_id: null,
+    delivery_status: "delivered",
+    error_code: null,
+    error_message: null,
+    retry_count: 0,
+    payload_json: null,
+    ai_model: null,
+    total_tokens: null,
+    created_at: note.created_at
+  };
+}
+
+export function useNotes(convId: string | null) {
+  const { token } = useAuth();
+  const store = useConvStore();
+
+  return useQuery({
+    queryKey: ["iv2-notes", convId],
+    queryFn: async () => {
+      const { notes } = await fetchConvNotes(token!, convId!);
+      store.setNotes(convId!, notes.map((n) => noteToMessage(n, convId!)));
+      return notes;
+    },
+    enabled: !!token && !!convId
+  });
+}
+
+export function useCreateNote() {
+  const { token } = useAuth();
+  const store = useConvStore();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ convId, content }: { convId: string; content: string }) =>
+      createConvNote(token!, convId, content),
+    onSuccess: (data, { convId }) => {
+      store.appendNote(convId, noteToMessage(data.note, convId));
+      void qc.invalidateQueries({ queryKey: ["iv2-notes", convId] });
+    }
   });
 }

--- a/apps/web/src/modules/dashboard/inbox-v2/route.tsx
+++ b/apps/web/src/modules/dashboard/inbox-v2/route.tsx
@@ -8,6 +8,8 @@ import { MessageThread } from "./components/MessageThread";
 import { DetailsSidebar } from "./components/DetailsSidebar";
 import { LeadFiltersPanel } from "./components/LeadFiltersPanel";
 import { NotificationsPanel } from "./components/NotificationsPanel";
+import { NewConvModal } from "./components/NewConvModal";
+import { CannedManageModal } from "./components/CannedManageModal";
 import "./inbox-v2.css";
 
 export function Component() {
@@ -16,6 +18,8 @@ export function Component() {
   const { token } = useAuth();
   const { setActiveConv, activeConvId, byId, ids } = useConvStore();
   const [showSidebar] = useState(true);
+  const [showNewConv, setShowNewConv] = useState(false);
+  const [showCannedManage, setShowCannedManage] = useState(false);
 
   const optimisticMap = useRealtimeSocket(token);
 
@@ -34,7 +38,11 @@ export function Component() {
       <NavSidebar conversations={conversations} />
 
       {/* Col 2: Conversation list */}
-      <ConversationList onSelectConv={handleSelectConv} />
+      <ConversationList
+        onSelectConv={handleSelectConv}
+        onNew={() => setShowNewConv(true)}
+        onCannedManage={() => setShowCannedManage(true)}
+      />
 
       {/* Col 3: Message thread */}
       {activeId ? (
@@ -50,6 +58,14 @@ export function Component() {
       {showSidebar && activeId && (
         <DetailsSidebar convId={activeId} />
       )}
+
+      {showNewConv && (
+        <NewConvModal
+          onClose={() => setShowNewConv(false)}
+          onCreated={(id) => { handleSelectConv(id); setShowNewConv(false); }}
+        />
+      )}
+      {showCannedManage && <CannedManageModal onClose={() => setShowCannedManage(false)} />}
     </div>
   );
 }

--- a/apps/web/src/modules/dashboard/inbox-v2/store/convStore.ts
+++ b/apps/web/src/modules/dashboard/inbox-v2/store/convStore.ts
@@ -10,6 +10,7 @@ export interface Conversation {
   id: string;
   user_id: string;
   phone_number: string;
+  contact_name: string | null;
   stage: string;
   score: number;
   lead_kind: string;
@@ -48,6 +49,8 @@ export interface ConversationMessage {
   error_message: string | null;
   retry_count: number;
   payload_json: Record<string, unknown> | null;
+  ai_model: string | null;
+  total_tokens: number | null;
   created_at: string;
 }
 
@@ -65,6 +68,8 @@ export interface ConvFilters {
   aiMode: string;     // "all" | "ai" | "human"
   assignment: string; // "all" | "assigned" | "unassigned"
   labelId: string;    // "all" | label.id
+  leadKind: string;   // "all" | "lead" | "feedback" | "complaint" | "other"
+  priority: string;   // "all" | "none" | "low" | "medium" | "high" | "urgent"
 }
 
 interface ConvStore {
@@ -77,6 +82,9 @@ interface ConvStore {
 
   // Messages per conversation
   messagesByConvId: Record<string, ConversationMessage[]>;
+
+  // Private notes per conversation (fetched from dedicated endpoint, not washed by setMessages)
+  notesByConvId: Record<string, ConversationMessage[]>;
 
   // Typing state per conversation
   typingState: Record<string, boolean>;
@@ -99,6 +107,9 @@ interface ConvStore {
   replaceOptimisticMessage: (convId: string, tempId: string, message: ConversationMessage) => void;
   patchMessageDelivery: (convId: string, msgId: string, status: MsgDeliveryStatus, errorCode?: string, errorMsg?: string) => void;
 
+  setNotes: (convId: string, notes: ConversationMessage[]) => void;
+  appendNote: (convId: string, note: ConversationMessage) => void;
+
   setTyping: (convId: string, on: boolean) => void;
   clearUnread: (convId: string) => void;
   setLabels: (labels: Label[]) => void;
@@ -109,7 +120,9 @@ const DEFAULT_FILTERS: ConvFilters = {
   channel: "all",
   aiMode: "all",
   assignment: "all",
-  labelId: "all"
+  labelId: "all",
+  leadKind: "all",
+  priority: "all"
 };
 
 export const useConvStore = create<ConvStore>((set) => ({
@@ -119,6 +132,7 @@ export const useConvStore = create<ConvStore>((set) => ({
   filters: DEFAULT_FILTERS,
   activeConvId: null,
   messagesByConvId: {},
+  notesByConvId: {},
   typingState: {},
   labels: [],
 
@@ -177,6 +191,16 @@ export const useConvStore = create<ConvStore>((set) => ({
       m.id === msgId ? { ...m, delivery_status: status, error_code: errorCode ?? m.error_code, error_message: errorMsg ?? m.error_message } : m
     );
     return { messagesByConvId: { ...s.messagesByConvId, [convId]: patched } };
+  }),
+
+  setNotes: (convId, notes) => set((s) => ({
+    notesByConvId: { ...s.notesByConvId, [convId]: notes }
+  })),
+
+  appendNote: (convId, note) => set((s) => {
+    const existing = s.notesByConvId[convId] ?? [];
+    if (existing.some((n) => n.id === note.id)) return s;
+    return { notesByConvId: { ...s.notesByConvId, [convId]: [...existing, note] } };
   }),
 
   setTyping: (convId, on) => set((s) => ({

--- a/apps/web/src/modules/dashboard/inbox-v2/types.ts
+++ b/apps/web/src/modules/dashboard/inbox-v2/types.ts
@@ -5,7 +5,7 @@ export interface WSEnvelope<E extends string, D> {
 }
 
 export type WSEvent =
-  | WSEnvelope<"message.created", { conversationId: string; message: { id: string; conversation_id: string; direction: string; sender_name: string | null; message_text: string; content_type: string; is_private: boolean; in_reply_to_id: string | null; echo_id: string | null; delivery_status: string; error_code: string | null; error_message: string | null; retry_count: number; created_at: string } }>
+  | WSEnvelope<"message.created", { conversationId: string; message: { id: string; conversation_id: string; direction: string; sender_name: string | null; message_text: string; content_type: string; is_private: boolean; in_reply_to_id: string | null; echo_id: string | null; delivery_status: string; error_code: string | null; error_message: string | null; retry_count: number; ai_model: string | null; total_tokens: number | null; created_at: string } }>
   | WSEnvelope<"message.updated", { messageId: string; conversationId: string; deliveryStatus: "sent" | "delivered" | "read" | "failed"; errorCode?: string; errorMessage?: string }>
   | WSEnvelope<"conversation.created", { id: string; last_message?: { text: string; sent_at: string; direction: string }; unread_count?: number; score?: number; status?: string; priority?: string }>
   | WSEnvelope<"conversation.updated", { id: string; last_message?: { text: string; sent_at: string; direction: string }; unread_count?: number; score?: number; status?: string; priority?: string }>


### PR DESCRIPTION
…ions, new conv, canned CRUD

- DetailsSidebar: snooze datetime picker (shows when status=snoozed, confirm button patches snoozed_until), conversation timeline accordion with all key events sorted chronologically
- MessageThread: tags bar (AI state, score band, priority, status pills), dismissable reply suggestion banner based on lead score
- ConversationList: bulk action bar with checkboxes on rows, Resolve/Reopen bulk mutations; + and ⚡ buttons trigger new conv and canned CRUD modals
- NewConvModal: create outbound conversation with phone, channel, optional initial message
- CannedManageModal: full CRUD for canned responses with inline edit, delete confirm
- api.ts: createOutboundConversation endpoint
- ComposeArea: fix filteredCanned/selectCanned declared before use (TS block-scoped error)
- CSS: thread tags bar, reply suggestion, bulk bar, row checkbox, modal overlay, timeline, canned manage rows